### PR TITLE
fix: Restore chat-to-Jira tool functionality

### DIFF
--- a/lib/tools/definitions.ts
+++ b/lib/tools/definitions.ts
@@ -591,11 +591,16 @@ export const ALL_TOOLS: ToolDefinition[] = [
 
 /**
  * Tool categories for UI filtering
+ * Keys match the MCP server IDs used in the sidebar (toolsData.tsx)
  */
-export const TOOL_CATEGORIES = {
-  incidents: ['rootly_get_incidents', 'rootly_update_incident', 'rootly_post_comment'],
-  github: ['github_get_prs'],
-  code: [
+export const TOOL_CATEGORIES: Record<string, string[]> = {
+  // Incidents - Rootly
+  rootly: ['rootly_get_incidents', 'rootly_update_incident', 'rootly_post_comment'],
+  incidents: ['rootly_get_incidents', 'rootly_update_incident', 'rootly_post_comment'], // Legacy alias
+
+  // GitHub - PRs and code operations
+  github: [
+    'github_get_prs',
     'github_read_file',
     'github_write_file',
     'github_delete_file',
@@ -606,9 +611,30 @@ export const TOOL_CATEGORIES = {
     'github_get_tree',
     'github_create_pr',
   ],
+  code: [ // Legacy alias for GitHub code tools
+    'github_read_file',
+    'github_write_file',
+    'github_delete_file',
+    'github_list_directory',
+    'github_create_branch',
+    'github_list_branches',
+    'github_search_code',
+    'github_get_tree',
+    'github_create_pr',
+  ],
+
+  // Jira - Issue tracking
   jira: ['jira_search_issues', 'jira_get_issue', 'jira_add_comment', 'jira_create_story'],
-  observability: ['newrelic_get_applications'],
-  analytics: ['metabase_list_databases', 'metabase_execute_query', 'metabase_search_questions', 'metabase_run_question'],
+
+  // New Relic - APM & Observability
+  newrelic: ['newrelic_get_applications'],
+  observability: ['newrelic_get_applications'], // Legacy alias
+
+  // Metabase - BI & Analytics
+  metabase: ['metabase_list_databases', 'metabase_execute_query', 'metabase_search_questions', 'metabase_run_question'],
+  analytics: ['metabase_list_databases', 'metabase_execute_query', 'metabase_search_questions', 'metabase_run_question'], // Legacy alias
+
+  // Web tools
   web: ['web_search', 'http_request'],
 };
 


### PR DESCRIPTION
Closes #11

## Summary
- Fixed issue where chat-to-Jira (and other integrations) stopped working
- The root cause was a mismatch between sidebar MCP server IDs and actual tool names

## Problem
The sidebar uses MCP server IDs like `jira`, `github`, `rootly` but the actual tools have names like `jira_create_story`, `github_get_prs`, etc. When filtering tools based on enabled MCP servers, no tools would match, effectively disabling all integrations.

## Solution
- Import `TOOL_CATEGORIES` mapping in the chat route
- Expand MCP server IDs to their corresponding tool names before filtering
- Updated `TOOL_CATEGORIES` to include all MCP server IDs from the sidebar

## Changes Made
- `app/api/chat/route.ts`: Added category ID expansion logic
- `lib/tools/definitions.ts`: Updated TOOL_CATEGORIES with proper MCP server ID mappings