### PR TITLE
Fix Sign In button showing unhelpful message

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -49,7 +49,25 @@ function SignInContent() {
 
       {/* Provider Buttons */}
       <div className="space-y-3">
-        {providers ? (
+        {providers === null ? (
+          // Loading skeleton
+          <div className="space-y-3">
+            <div className="h-12 rounded-xl bg-md-surface-container-high animate-pulse" />
+            <div className="h-12 rounded-xl bg-md-surface-container-high animate-pulse" />
+          </div>
+        ) : Object.keys(providers).length === 0 ? (
+          // No providers configured
+          <div className="text-center py-4">
+            <Icon name="warning" size={32} className="text-md-error mx-auto mb-3" />
+            <p className="text-sm text-md-on-surface-variant mb-3">
+              No authentication providers configured.
+            </p>
+            <p className="text-xs text-md-on-surface-variant">
+              Add OAuth credentials (GITHUB_ID, GITHUB_SECRET or GOOGLE_ID, GOOGLE_SECRET)
+              to your environment variables.
+            </p>
+          </div>
+        ) : (
           Object.values(providers).map((provider) => (
             <button
               key={provider.id}
@@ -70,12 +88,6 @@ function SignInContent() {
               Continue with {provider.name}
             </button>
           ))
-        ) : (
-          // Loading skeleton
-          <div className="space-y-3">
-            <div className="h-12 rounded-xl bg-md-surface-container-high animate-pulse" />
-            <div className="h-12 rounded-xl bg-md-surface-container-high animate-pulse" />
-          </div>
         )}
       </div>
     </>


### PR DESCRIPTION
Closes #24

## Summary
When users click Sign In but no OAuth providers are configured (missing `GITHUB_ID`/`GITHUB_SECRET` or `GOOGLE_ID`/`GOOGLE_SECRET` env vars), the sign-in page was showing an empty provider list with no explanation.

This fix adds a clear warning message explaining what environment variables need to be configured.

## Changes Made
- Updated `app/auth/signin/page.tsx` to display a helpful warning message when no OAuth providers are detected
- Shows a warning icon with instructions to add OAuth credentials

## Before
Empty sign-in page with no provider buttons and no explanation

## After
Clear warning message: "No authentication providers configured" with instructions to add OAuth credentials

## Note
The `.env.example` file is currently gitignored (via `.env*` pattern). A follow-up task should update `.gitignore` to allow tracking `.env.example` and add the OAuth configuration documentation there.