### PR TITLE
Stop calling auth so many times

### DIFF
--- a/components/auth/SessionProvider.tsx
+++ b/components/auth/SessionProvider.tsx
@@ -4,5 +4,14 @@ import { SessionProvider as NextAuthSessionProvider } from "next-auth/react"
 import { type ReactNode } from "react"
 
 export function SessionProvider({ children }: { children: ReactNode }) {
-  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>
+  return (
+    <NextAuthSessionProvider
+      // Disable automatic session polling - only fetch on mount and when explicitly needed
+      // This prevents the repeated /api/auth/session calls seen in logs
+      refetchInterval={0}
+      refetchOnWindowFocus={false}
+    >
+      {children}
+    </NextAuthSessionProvider>
+  )
 }


### PR DESCRIPTION
Closes #26

## Summary
- Configured SessionProvider to disable automatic session polling
- Set `refetchInterval=0` to stop periodic session checks
- Set `refetchOnWindowFocus=false` to prevent refetch when switching tabs

## Problem
The logs showed `/api/auth/session` being called repeatedly (10+ times in quick succession) due to next-auth's default polling behavior.

## Solution
The next-auth `SessionProvider` has two default behaviors that cause excessive API calls:
1. `refetchInterval` - periodically polls the session endpoint
2. `refetchOnWindowFocus` - refetches session every time the browser tab gains focus

Setting both to disabled values eliminates the unnecessary calls while still maintaining session state on initial mount and when explicitly needed.