### PR TITLE
Fix OAuth avatar image error

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,18 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   devIndicators: false,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #31

## Summary

Fixes the runtime error when displaying user avatars after OAuth login:

```
Invalid src prop (https://avatars.githubusercontent.com/u/...) on `next/image`,
hostname "avatars.githubusercontent.com" is not configured under images in your `next.config.js`
```

## Changes

Added `images.remotePatterns` to `next.config.ts` to allow:
- `avatars.githubusercontent.com` - GitHub profile pictures
- `lh3.googleusercontent.com` - Google profile pictures (preemptively added for Google OAuth)