### PR TITLE
Create a github action to automatically launch claude when a new issue is created

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -1,0 +1,87 @@
+name: Claude Auto-Implement
+
+# Trigger on issues with 'claude-implement' label or @claude mentions
+on:
+  issues:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  implement:
+    # Only run if:
+    # 1. Issue has 'claude-implement' label, OR
+    # 2. Comment contains @claude mention
+    if: |
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'claude-implement')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Action
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # For labeled issues, provide implementation instructions
+          # For @claude mentions, the action responds automatically
+          prompt: |
+            You are implementing GitHub issue #${{ github.event.issue.number }}.
+
+            ISSUE TITLE: ${{ github.event.issue.title }}
+
+            ISSUE BODY:
+            ${{ github.event.issue.body }}
+
+            INSTRUCTIONS:
+            1. Read the CLAUDE.md file for project-specific guidelines
+            2. Analyze the issue requirements thoroughly
+            3. Create a feature branch following the pattern: {issue_number}-{issue-title-kebab-case}
+               Example: 037-create-github-action-auto-launch-claude
+            4. Implement the requested changes
+            5. Write clean, well-documented code following existing patterns
+            6. Run any relevant tests or linting
+            7. Commit changes with a descriptive message referencing the issue
+            8. Create a pull request that closes #${{ github.event.issue.number }}
+
+            Use `gh` CLI for GitHub operations.
+            Follow existing code patterns and conventions in this repository.
+
+          # Allow Claude to use necessary tools
+          allowed_tools: |
+            Read
+            Write
+            Edit
+            Bash(git:*)
+            Bash(gh:*)
+            Bash(npm:*)
+            Bash(npx:*)
+            Glob
+            Grep
+
+          # Limit turns to prevent runaway execution
+          max_turns: 50
+
+      - name: Comment on issue if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '❌ Claude encountered an error while implementing this issue. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+            });

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -1,0 +1,78 @@
+name: Claude Issue Triage
+
+# Automatically analyze and label new issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Triage Issue with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          prompt: |
+            Analyze this new GitHub issue and triage it appropriately.
+
+            REPOSITORY: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+            TITLE: ${{ github.event.issue.title }}
+            AUTHOR: ${{ github.event.issue.user.login }}
+
+            BODY:
+            ${{ github.event.issue.body }}
+
+            TRIAGE INSTRUCTIONS:
+            1. Determine the issue type:
+               - bug: Something isn't working correctly
+               - enhancement: New feature or improvement request
+               - documentation: Documentation updates needed
+               - question: User needs help or clarification
+
+            2. Assess complexity:
+               - good first issue: Simple, well-defined, good for newcomers
+               - help wanted: Could use community contribution
+               - complex: Requires significant effort or expertise
+
+            3. Identify area:
+               - frontend: UI/UX related
+               - backend: API, database, server-side
+               - auth: Authentication/authorization
+               - ai: AI/Claude integration
+               - infra: DevOps, CI/CD, deployment
+
+            4. Check for:
+               - Missing information that should be requested
+               - Duplicate issues (search existing issues)
+               - Security concerns that need immediate attention
+
+            ACTIONS TO TAKE:
+            - Add appropriate labels using: gh issue edit ${{ github.event.issue.number }} --add-label "label1,label2"
+            - If the issue is clear and well-scoped, consider adding 'claude-implement' label
+            - If information is missing, post a comment asking for clarification
+            - If it appears to be a duplicate, comment with a link to the original
+
+            Be conservative with the 'claude-implement' label - only add it for well-defined,
+            straightforward tasks that can be implemented without human guidance.
+
+          allowed_tools: |
+            Bash(gh issue:*)
+            Bash(gh search:*)
+            Read
+            Grep
+
+          max_turns: 10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,63 @@ gh pr merge --squash --delete-branch
 2. Use kebab-case for the title portion
 3. Keep branch names concise but descriptive
 4. Maximum 50 characters for the title portion
+
+---
+
+## Automated Issue Implementation (GitHub Actions)
+
+TheBridge uses Claude Code GitHub Actions to automatically implement issues.
+
+### How It Works
+
+1. **Issue Triage** (`claude-triage.yml`): When a new issue is opened, Claude automatically:
+   - Analyzes the issue content
+   - Adds appropriate labels (bug, enhancement, frontend, backend, etc.)
+   - Identifies if it's a good candidate for auto-implementation
+   - Optionally adds the `claude-implement` label for straightforward tasks
+
+2. **Auto-Implementation** (`claude-implement.yml`): When an issue has the `claude-implement` label:
+   - Claude reads the issue and CLAUDE.md guidelines
+   - Creates a feature branch following naming conventions
+   - Implements the requested changes
+   - Creates a pull request that closes the issue
+
+### Triggering Implementation
+
+**Automatic (via label):**
+- Add the `claude-implement` label to any issue
+- Claude will begin implementation automatically
+
+**Manual (via mention):**
+- Comment `@claude implement this` on any issue
+- Claude will respond and begin implementation
+
+### Required Setup
+
+1. **Add the Anthropic API Key** to repository secrets:
+   ```
+   Settings → Secrets and variables → Actions → New repository secret
+   Name: ANTHROPIC_API_KEY
+   Value: <your-api-key>
+   ```
+
+2. **Create the `claude-implement` label** (optional, for safety):
+   ```bash
+   gh label create claude-implement --color "5319E7" --description "Claude will auto-implement this issue"
+   ```
+
+### Safety Controls
+
+- Issues require the `claude-implement` label for automatic implementation
+- The triage workflow is conservative about adding this label
+- Complex or ambiguous issues are flagged for human review
+- Failed implementations post a comment with the workflow run link
+
+### Best Practices for Issues
+
+For best auto-implementation results, write issues that include:
+- Clear, specific title describing the task
+- Detailed description of what needs to be done
+- Acceptance criteria or expected behavior
+- Any relevant file paths or code references
+- Edge cases or constraints to consider


### PR DESCRIPTION
Closes #37

## Summary
Adds GitHub Actions workflows that enable Claude Code to automatically implement issues without manual intervention.

## Changes Made

### New Workflows

1. **`.github/workflows/claude-triage.yml`** - Issue Triage
   - Triggers on new issue creation
   - Analyzes issue content to determine type (bug, enhancement, docs, question)
   - Assesses complexity and identifies the relevant area (frontend, backend, auth, etc.)
   - Searches for duplicate issues
   - Conservatively adds `claude-implement` label for well-scoped tasks

2. **`.github/workflows/claude-implement.yml`** - Auto-Implementation  
   - Triggers when `claude-implement` label is added OR `@claude` is mentioned
   - Reads CLAUDE.md for project guidelines
   - Creates feature branch following naming conventions
   - Implements the requested changes
   - Creates a PR that closes the issue
   - Posts error comments if implementation fails

### Safety Controls
- **Label-gated**: Automatic implementation requires the `claude-implement` label
- **Tool restrictions**: Limited to necessary tools via `allowed_tools`
- **Turn limits**: Max 50 turns for implementation, 10 for triage
- **Failure handling**: Comments on issue with link to failed workflow run

### Documentation
Updated `CLAUDE.md` with:
- How the automation works
- Triggering methods (label vs @mention)
- Required setup (API key secret, label creation)
- Best practices for writing auto-implementable issues

## Setup Required
1. Add `ANTHROPIC_API_KEY` to repository secrets
2. Optionally create the `claude-implement` label:
   ```bash
   gh label create claude-implement --color "5319E7" --description "Claude will auto-implement this issue"
   ```

## Test Plan
- [ ] Add ANTHROPIC_API_KEY secret to repo
- [ ] Create a simple test issue with clear requirements
- [ ] Add `claude-implement` label and verify workflow runs
- [ ] Check that PR is created correctly