### PR TITLE
Create logged out landing page

### DIFF
--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -3,8 +3,7 @@
 import { Suspense } from "react"
 import { useSearchParams } from "next/navigation"
 import Link from "next/link"
-import Image from "next/image"
-import Icon from "@/components/ui/Icon"
+import { AuthLayout } from "@/components/auth"
 
 const errorMessages: Record<string, { title: string; description: string }> = {
   Configuration: {
@@ -67,61 +66,79 @@ function ErrorContent() {
   const { title, description } = errorMessages[error] || errorMessages.Default
 
   return (
-    <>
+    <div className="text-center">
       {/* Error Icon */}
-      <div className="flex justify-center mb-4">
-        <div className="w-16 h-16 rounded-full bg-md-error-container flex items-center justify-center">
-          <Icon name="error" size={32} className="text-md-error" />
+      <div className="flex justify-center mb-6">
+        <div
+          className="w-20 h-20 rounded-full flex items-center justify-center"
+          style={{ background: 'var(--md-error-container)' }}
+        >
+          <span
+            className="material-symbols-outlined text-4xl"
+            style={{ color: 'var(--md-error)' }}
+          >
+            error
+          </span>
         </div>
       </div>
 
       {/* Error Message */}
-      <h1 className="text-xl font-semibold text-md-on-surface mb-2">{title}</h1>
-      <p className="text-sm text-md-on-surface-variant mb-8">{description}</p>
-    </>
+      <h1
+        className="text-2xl font-bold mb-3"
+        style={{ color: 'var(--md-on-surface)' }}
+      >
+        {title}
+      </h1>
+      <p
+        className="text-base mb-8"
+        style={{ color: 'var(--md-on-surface-variant)' }}
+      >
+        {description}
+      </p>
+
+      {/* Actions */}
+      <div className="space-y-3">
+        <Link
+          href="/auth/signin"
+          className="block w-full px-6 py-4 rounded-xl font-medium
+            transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+          style={{
+            background: 'var(--md-primary)',
+            color: 'var(--md-on-primary)',
+          }}
+        >
+          Try Again
+        </Link>
+        <Link
+          href="/"
+          className="block w-full px-6 py-4 rounded-xl font-medium
+            transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+          style={{
+            background: 'var(--md-surface-container-high)',
+            border: '1px solid var(--md-outline)',
+            color: 'var(--md-on-surface)',
+          }}
+        >
+          Go Home
+        </Link>
+      </div>
+    </div>
   )
 }
 
 export default function AuthErrorPage() {
   return (
-    <div className="min-h-full flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-sm text-center">
-        {/* Logo */}
-        <div className="flex justify-center mb-8">
-          <Image
-            src="/thebridge-logo-dark.svg"
-            alt="TheBridge"
-            width={180}
-            height={50}
-            priority
-            className="h-12 w-auto"
+    <AuthLayout>
+      <Suspense
+        fallback={
+          <div
+            className="h-48 rounded-xl animate-pulse"
+            style={{ background: 'var(--md-surface-container-high)' }}
           />
-        </div>
-
-        <Suspense fallback={<div className="h-32 animate-pulse" />}>
-          <ErrorContent />
-        </Suspense>
-
-        {/* Actions */}
-        <div className="space-y-3">
-          <Link
-            href="/auth/signin"
-            className="block w-full px-4 py-3 rounded-xl
-              bg-md-primary text-md-on-primary font-medium
-              hover:bg-md-primary/90 transition-colors"
-          >
-            Try Again
-          </Link>
-          <Link
-            href="/"
-            className="block w-full px-4 py-3 rounded-xl
-              border border-md-outline text-md-on-surface font-medium
-              hover:bg-md-surface-container-high transition-colors"
-          >
-            Go Home
-          </Link>
-        </div>
-      </div>
-    </div>
+        }
+      >
+        <ErrorContent />
+      </Suspense>
+    </AuthLayout>
   )
 }

--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -1,0 +1,16 @@
+/**
+ * Auth Layout - Special layout for auth pages
+ * Removes the standard header/footer chrome so auth pages
+ * can use their own full-screen split layout
+ */
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="fixed inset-0 z-50 bg-[var(--md-surface)]">
+      {children}
+    </div>
+  )
+}

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -4,18 +4,13 @@ import { Suspense } from "react"
 import { signIn, getProviders } from "next-auth/react"
 import { useEffect, useState } from "react"
 import { useSearchParams } from "next/navigation"
-import Image from "next/image"
-import Icon from "@/components/ui/Icon"
+import Link from "next/link"
+import { AuthLayout } from "@/components/auth"
 
 type Provider = {
   id: string
   name: string
   type: string
-}
-
-const providerIcons: Record<string, string> = {
-  github: "code",
-  google: "mail",
 }
 
 function SignInContent() {
@@ -35,11 +30,36 @@ function SignInContent() {
   }
 
   return (
-    <>
+    <div>
+      {/* Page Title */}
+      <div className="mb-8">
+        <h1
+          className="text-3xl font-bold mb-3"
+          style={{ color: 'var(--md-on-surface)' }}
+        >
+          Welcome Back
+        </h1>
+        <p
+          className="text-base"
+          style={{ color: 'var(--md-on-surface-variant)' }}
+        >
+          Sign in to access your SRE command center and AI-powered incident management.
+        </p>
+      </div>
+
       {/* Error Message */}
       {error && (
-        <div className="mb-6 p-3 rounded-lg bg-md-error-container/20 border border-md-error/30">
-          <p className="text-sm text-md-error text-center">
+        <div
+          className="mb-6 p-4 rounded-xl"
+          style={{
+            background: 'var(--md-error-container)',
+            border: '1px solid var(--md-error)',
+          }}
+        >
+          <p
+            className="text-sm"
+            style={{ color: 'var(--md-on-error-container)' }}
+          >
             {error === "OAuthAccountNotLinked"
               ? "This email is already associated with another account."
               : "An error occurred during sign in. Please try again."}
@@ -48,99 +68,132 @@ function SignInContent() {
       )}
 
       {/* Provider Buttons */}
-      <div className="space-y-3">
+      <div className="space-y-4">
         {providers === null ? (
           // Loading skeleton
-          <div className="space-y-3">
-            <div className="h-12 rounded-xl bg-md-surface-container-high animate-pulse" />
-            <div className="h-12 rounded-xl bg-md-surface-container-high animate-pulse" />
+          <div className="space-y-4">
+            <div
+              className="h-14 rounded-xl animate-pulse"
+              style={{ background: 'var(--md-surface-container-high)' }}
+            />
           </div>
         ) : Object.keys(providers).length === 0 ? (
           // No providers configured
-          <div className="text-center py-4">
-            <Icon name="warning" size={32} className="text-md-error mx-auto mb-3" />
-            <p className="text-sm text-md-on-surface-variant mb-3">
+          <div className="text-center py-6">
+            <span
+              className="material-symbols-outlined text-4xl mb-4 block"
+              style={{ color: 'var(--md-error)' }}
+            >
+              warning
+            </span>
+            <p
+              className="text-sm mb-3"
+              style={{ color: 'var(--md-on-surface-variant)' }}
+            >
               No authentication providers configured.
             </p>
-            <p className="text-xs text-md-on-surface-variant">
-              Add OAuth credentials (GITHUB_ID, GITHUB_SECRET or GOOGLE_ID, GOOGLE_SECRET)
+            <p
+              className="text-xs"
+              style={{ color: 'var(--md-on-surface-variant)' }}
+            >
+              Add GitHub OAuth credentials (GITHUB_ID, GITHUB_SECRET)
               to your environment variables.
             </p>
           </div>
         ) : (
-          Object.values(providers).map((provider) => (
-            <button
-              key={provider.id}
-              onClick={() => handleSignIn(provider.id)}
-              disabled={isLoading !== null}
-              className="w-full flex items-center justify-center gap-3 px-4 py-3
-                rounded-xl border border-md-outline
-                bg-md-surface hover:bg-md-surface-container-high
-                text-md-on-surface font-medium
-                transition-colors duration-150
-                disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isLoading === provider.id ? (
-                <span className="w-5 h-5 border-2 border-md-primary/30 border-t-md-primary rounded-full animate-spin" />
-              ) : (
-                <Icon name={providerIcons[provider.id] || "account_circle"} size={20} />
-              )}
-              Continue with {provider.name}
-            </button>
-          ))
+          <>
+            {/* GitHub Sign In Button - Primary option */}
+            {providers.github && (
+              <button
+                onClick={() => handleSignIn("github")}
+                disabled={isLoading !== null}
+                className="w-full flex items-center justify-center gap-3 px-6 py-4
+                  rounded-xl font-medium text-base
+                  transition-all duration-200
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                  hover:scale-[1.02] active:scale-[0.98]"
+                style={{
+                  background: 'var(--md-surface-container-high)',
+                  border: '1px solid var(--md-outline)',
+                  color: 'var(--md-on-surface)',
+                }}
+              >
+                {isLoading === "github" ? (
+                  <span
+                    className="w-6 h-6 border-2 rounded-full animate-spin"
+                    style={{
+                      borderColor: 'var(--md-outline)',
+                      borderTopColor: 'var(--md-primary)',
+                    }}
+                  />
+                ) : (
+                  <GitHubIcon />
+                )}
+                Continue with GitHub
+              </button>
+            )}
+          </>
         )}
       </div>
-    </>
+
+      {/* Terms */}
+      <p
+        className="text-center text-xs mt-8"
+        style={{ color: 'var(--md-on-surface-variant)' }}
+      >
+        By signing in, you agree to our{" "}
+        <Link
+          href="/terms"
+          className="hover:underline"
+          style={{ color: 'var(--md-primary)' }}
+        >
+          Terms of Service
+        </Link>{" "}
+        and{" "}
+        <Link
+          href="/privacy"
+          className="hover:underline"
+          style={{ color: 'var(--md-primary)' }}
+        >
+          Privacy Policy
+        </Link>
+      </p>
+    </div>
+  )
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      className="w-6 h-6"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+        clipRule="evenodd"
+      />
+    </svg>
   )
 }
 
 export default function SignInPage() {
   return (
-    <div className="min-h-full flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-sm">
-        {/* Logo */}
-        <div className="flex justify-center mb-8">
-          <Image
-            src="/thebridge-logo-dark.svg"
-            alt="TheBridge"
-            width={180}
-            height={50}
-            priority
-            className="h-12 w-auto"
-          />
-        </div>
-
-        {/* Card */}
-        <div className="bg-md-surface-container rounded-2xl p-8 shadow-lg border border-md-outline-variant">
-          <h1 className="text-xl font-semibold text-md-on-surface text-center mb-2">
-            Welcome to TheBridge
-          </h1>
-          <p className="text-sm text-md-on-surface-variant text-center mb-6">
-            Sign in to access your SRE command center
-          </p>
-
-          <Suspense fallback={
-            <div className="space-y-3">
-              <div className="h-12 rounded-xl bg-md-surface-container-high animate-pulse" />
-              <div className="h-12 rounded-xl bg-md-surface-container-high animate-pulse" />
-            </div>
-          }>
-            <SignInContent />
-          </Suspense>
-        </div>
-
-        {/* Footer */}
-        <p className="text-xs text-md-on-surface-variant text-center mt-6">
-          By signing in, you agree to our{" "}
-          <a href="/terms" className="text-md-primary hover:underline">
-            Terms of Service
-          </a>{" "}
-          and{" "}
-          <a href="/privacy" className="text-md-primary hover:underline">
-            Privacy Policy
-          </a>
-        </p>
-      </div>
-    </div>
+    <AuthLayout>
+      <Suspense
+        fallback={
+          <div className="space-y-4">
+            <div
+              className="h-14 rounded-xl animate-pulse"
+              style={{ background: 'var(--md-surface-container-high)' }}
+            />
+          </div>
+        }
+      >
+        <SignInContent />
+      </Suspense>
+    </AuthLayout>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,11 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Header from "@/components/Header";
-import Footer from "@/components/Footer";
+import { AppShell } from "@/components/AppShell";
 import { ThemeProvider } from "@/lib/theme";
 import { RoleProvider } from "@/contexts/RoleContext";
 import { MultiAgentProvider } from "@/contexts/MultiAgentContext";
 import { DashboardProvider } from "@/contexts/DashboardContext";
-import { SkipLinks } from "@/components/accessibility";
 import { SessionProvider } from "@/components/auth";
 
 // Material Symbols font URL
@@ -49,12 +47,9 @@ export default function RootLayout({
             <RoleProvider>
               <MultiAgentProvider>
                 <DashboardProvider>
-                  <SkipLinks />
-                  <Header />
-                  <main id="main-content" className="flex-1 flex flex-col min-h-0 overflow-hidden" role="main">
+                  <AppShell>
                     {children}
-                  </main>
-                  <Footer />
+                  </AppShell>
                 </DashboardProvider>
               </MultiAgentProvider>
             </RoleProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useState, useCallback, useRef } from 'react';
+import { useSession } from "next-auth/react";
 import ChatInterface, { ChatInterfaceHandle } from "@/components/ChatInterface";
 import ToolsSidebar, { ALL_TOOL_IDS } from "@/components/ToolsSidebar";
 import DashboardGrid from "@/components/dashboard/DashboardGrid";
 import MultiAgentGrid from "@/components/MultiAgentGrid";
 import PromptEditorPanel from "@/components/PromptEditorPanel";
+import { LandingPage } from "@/components/LandingPage";
 import { useMultiAgent } from "@/contexts/MultiAgentContext";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useRole } from "@/contexts/RoleContext";
@@ -14,6 +16,11 @@ import type { OpenAgent } from "@/components/AgentPanelContainer";
 export type SidebarMode = 'hidden' | 'mini' | 'full';
 
 export default function Home() {
+  // Auth state
+  const { data: session, status } = useSession();
+  const isAuthenticated = !!session;
+  const isLoading = status === "loading";
+
   // Default all tools to enabled
   const [enabledTools, setEnabledTools] = useState<Set<string>>(new Set(ALL_TOOL_IDS));
   // Sidebar mode - hidden, mini (icons + abbreviated names), or full
@@ -221,6 +228,29 @@ export default function Home() {
       return 'hidden';
     });
   }, []);
+
+  // Show loading spinner during auth check
+  if (isLoading) {
+    return (
+      <div
+        className="flex-1 flex items-center justify-center"
+        style={{ background: 'var(--md-surface)' }}
+      >
+        <div
+          className="w-8 h-8 border-2 rounded-full animate-spin"
+          style={{
+            borderColor: 'var(--md-outline)',
+            borderTopColor: 'var(--md-primary)',
+          }}
+        />
+      </div>
+    );
+  }
+
+  // Show landing page for logged-out users
+  if (!isAuthenticated) {
+    return <LandingPage />;
+  }
 
   return (
     <div className="flex-1 flex overflow-hidden relative">

--- a/auth.ts
+++ b/auth.ts
@@ -1,28 +1,17 @@
 import NextAuth from "next-auth"
 import { PrismaAdapter } from "@auth/prisma-adapter"
 import GitHub from "next-auth/providers/github"
-import Google from "next-auth/providers/google"
 import { prisma } from "@/lib/db"
 
-// Build providers array dynamically based on available credentials
+// Build providers array - GitHub only
 const providers = []
 
-// GitHub OAuth (optional)
+// GitHub OAuth (required for authentication)
 if (process.env.GITHUB_ID && process.env.GITHUB_SECRET) {
   providers.push(
     GitHub({
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
-    })
-  )
-}
-
-// Google OAuth (optional)
-if (process.env.GOOGLE_ID && process.env.GOOGLE_SECRET) {
-  providers.push(
-    Google({
-      clientId: process.env.GOOGLE_ID,
-      clientSecret: process.env.GOOGLE_SECRET,
     })
   )
 }

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useSession } from "next-auth/react"
+import Header from "@/components/Header"
+import Footer from "@/components/Footer"
+import { SkipLinks } from "@/components/accessibility"
+
+interface AppShellProps {
+  children: React.ReactNode
+}
+
+/**
+ * AppShell - Conditional layout wrapper
+ * Shows header/footer only for authenticated users
+ * Logged-out users see the landing page with its own navigation
+ */
+export function AppShell({ children }: AppShellProps) {
+  const { data: session, status } = useSession()
+  const isAuthenticated = !!session
+  const isLoading = status === "loading"
+
+  // During loading, show minimal shell to prevent flash
+  if (isLoading) {
+    return (
+      <>
+        <main
+          id="main-content"
+          className="flex-1 flex flex-col min-h-0 overflow-hidden"
+          role="main"
+        >
+          {children}
+        </main>
+      </>
+    )
+  }
+
+  // For logged-out users, render children directly (landing page has its own nav)
+  if (!isAuthenticated) {
+    return (
+      <main
+        id="main-content"
+        className="flex-1 flex flex-col min-h-0 overflow-hidden"
+        role="main"
+      >
+        {children}
+      </main>
+    )
+  }
+
+  // For authenticated users, show full app chrome
+  return (
+    <>
+      <SkipLinks />
+      <Header />
+      <main
+        id="main-content"
+        className="flex-1 flex flex-col min-h-0 overflow-hidden"
+        role="main"
+      >
+        {children}
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,0 +1,408 @@
+"use client"
+
+import Image from "next/image"
+import Link from "next/link"
+import { signIn } from "next-auth/react"
+import { ThemeSwitch } from "@/components/ThemeSwitch"
+import { useTheme } from "@/lib/theme"
+
+/**
+ * Landing page shown to logged-out users
+ * Full-screen hero with product features and call-to-action
+ */
+export function LandingPage() {
+  const { currentTheme } = useTheme()
+  const isDark = currentTheme.mode === "dark"
+
+  return (
+    <div
+      className="min-h-screen flex flex-col"
+      style={{ background: 'var(--md-surface)' }}
+    >
+      {/* Navigation */}
+      <nav
+        className="h-16 px-6 flex items-center justify-between"
+        style={{ borderBottom: '1px solid var(--md-outline-variant)' }}
+      >
+        <Link href="/" className="hover:opacity-80 transition-opacity">
+          <Image
+            src={isDark ? "/thebridge-logo-dark.svg" : "/thebridge-logo-light.svg"}
+            alt="TheBridge"
+            width={140}
+            height={40}
+            priority
+            className="h-8 w-auto"
+          />
+        </Link>
+
+        <div className="flex items-center gap-3">
+          <ThemeSwitch />
+          <button
+            onClick={() => signIn("github")}
+            className="px-4 py-2 rounded-lg font-medium text-sm
+              transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+            style={{
+              background: 'var(--md-primary)',
+              color: 'var(--md-on-primary)',
+            }}
+          >
+            Sign In with GitHub
+          </button>
+        </div>
+      </nav>
+
+      {/* Hero Section */}
+      <div className="flex-1 flex">
+        {/* Left Content */}
+        <div className="flex-1 flex flex-col justify-center px-8 lg:px-16 py-12">
+          <div className="max-w-xl">
+            {/* Badge */}
+            <div
+              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium mb-6"
+              style={{
+                background: 'var(--md-primary-container)',
+                color: 'var(--md-on-primary-container)',
+              }}
+            >
+              <span
+                className="material-symbols-outlined text-sm"
+                style={{ fontVariationSettings: "'FILL' 1" }}
+              >
+                auto_awesome
+              </span>
+              AI-Powered SRE Platform
+            </div>
+
+            {/* Headline */}
+            <h1
+              className="text-4xl lg:text-5xl font-bold leading-tight mb-6"
+              style={{ color: 'var(--md-on-surface)' }}
+            >
+              Your AI-Powered
+              <br />
+              <span style={{ color: 'var(--md-primary)' }}>SRE Command Center</span>
+            </h1>
+
+            {/* Subheadline */}
+            <p
+              className="text-lg lg:text-xl mb-8 leading-relaxed"
+              style={{ color: 'var(--md-on-surface-variant)' }}
+            >
+              Connect all your observability tools. Let AI agents analyze incidents,
+              suggest fixes, and automate responses. Reduce MTTR by 60%.
+            </p>
+
+            {/* CTA Buttons */}
+            <div className="flex flex-col sm:flex-row gap-4">
+              <button
+                onClick={() => signIn("github")}
+                className="flex items-center justify-center gap-3 px-6 py-4 rounded-xl
+                  font-medium text-base transition-all duration-200
+                  hover:scale-[1.02] active:scale-[0.98]"
+                style={{
+                  background: 'var(--md-primary)',
+                  color: 'var(--md-on-primary)',
+                }}
+              >
+                <GitHubIcon />
+                Get Started with GitHub
+              </button>
+              <Link
+                href="#features"
+                className="flex items-center justify-center gap-2 px-6 py-4 rounded-xl
+                  font-medium text-base transition-all duration-200
+                  hover:scale-[1.02] active:scale-[0.98]"
+                style={{
+                  background: 'var(--md-surface-container-high)',
+                  border: '1px solid var(--md-outline)',
+                  color: 'var(--md-on-surface)',
+                }}
+              >
+                <span className="material-symbols-outlined text-xl">play_circle</span>
+                Watch Demo
+              </Link>
+            </div>
+
+            {/* Trust Signals */}
+            <div
+              className="flex items-center gap-6 mt-8 pt-8"
+              style={{ borderTop: '1px solid var(--md-outline-variant)' }}
+            >
+              <TrustItem icon="check_circle" text="Free to start" />
+              <TrustItem icon="lock" text="Enterprise security" />
+              <TrustItem icon="bolt" text="5-min setup" />
+            </div>
+          </div>
+        </div>
+
+        {/* Right Visual */}
+        <div
+          className="hidden lg:flex lg:w-1/2 items-center justify-center p-12 relative overflow-hidden"
+          style={{
+            background: `linear-gradient(135deg,
+              var(--md-primary-container) 0%,
+              var(--md-secondary-container) 50%,
+              var(--md-surface-container) 100%)`
+          }}
+        >
+          {/* Decorative background pattern */}
+          <div
+            className="absolute inset-0 opacity-10"
+            style={{
+              backgroundImage: `radial-gradient(circle at 25px 25px, var(--md-on-surface) 2px, transparent 0)`,
+              backgroundSize: '50px 50px',
+            }}
+          />
+
+          {/* Feature Cards Stack */}
+          <div className="relative w-full max-w-md space-y-4">
+            <FeatureCard
+              icon="monitoring"
+              title="Unified Observability"
+              description="Connect Rootly, New Relic, Coralogix, and more in one place"
+            />
+            <FeatureCard
+              icon="psychology"
+              title="AI Agents"
+              description="Specialized agents for different SRE tasks work together"
+            />
+            <FeatureCard
+              icon="bolt"
+              title="Instant Insights"
+              description="Get AI-powered analysis of incidents in seconds"
+            />
+            <FeatureCard
+              icon="group"
+              title="Team Collaboration"
+              description="Share context and coordinate responses efficiently"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Features Section */}
+      <section
+        id="features"
+        className="py-20 px-8"
+        style={{ background: 'var(--md-surface-container)' }}
+      >
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-12">
+            <h2
+              className="text-3xl font-bold mb-4"
+              style={{ color: 'var(--md-on-surface)' }}
+            >
+              Everything you need for SRE excellence
+            </h2>
+            <p
+              className="text-lg max-w-2xl mx-auto"
+              style={{ color: 'var(--md-on-surface-variant)' }}
+            >
+              Connect your tools, let AI do the heavy lifting, and focus on what matters.
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-6">
+            <IntegrationCard
+              title="Rootly"
+              description="Incident management with full context"
+              icon="crisis_alert"
+            />
+            <IntegrationCard
+              title="New Relic"
+              description="APM and infrastructure monitoring"
+              icon="monitoring"
+            />
+            <IntegrationCard
+              title="Coralogix"
+              description="Log analytics and observability"
+              icon="description"
+            />
+            <IntegrationCard
+              title="GitHub"
+              description="Code and deployment integration"
+              icon="code"
+            />
+            <IntegrationCard
+              title="Uptime Kuma"
+              description="Status page and uptime monitoring"
+              icon="check_circle"
+            />
+            <IntegrationCard
+              title="More Coming"
+              description="PagerDuty, Datadog, Slack..."
+              icon="add_circle"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer
+        className="py-8 px-8"
+        style={{
+          background: 'var(--md-surface)',
+          borderTop: '1px solid var(--md-outline-variant)',
+        }}
+      >
+        <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+          <p
+            className="text-sm"
+            style={{ color: 'var(--md-on-surface-variant)' }}
+          >
+            &copy; {new Date().getFullYear()} TheBridge. All rights reserved.
+          </p>
+          <div className="flex items-center gap-6">
+            <Link
+              href="/terms"
+              className="text-sm hover:underline"
+              style={{ color: 'var(--md-on-surface-variant)' }}
+            >
+              Terms
+            </Link>
+            <Link
+              href="/privacy"
+              className="text-sm hover:underline"
+              style={{ color: 'var(--md-on-surface-variant)' }}
+            >
+              Privacy
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      className="w-5 h-5"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}
+
+function TrustItem({ icon, text }: { icon: string; text: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className="material-symbols-outlined text-lg"
+        style={{
+          color: 'var(--md-primary)',
+          fontVariationSettings: "'FILL' 1",
+        }}
+      >
+        {icon}
+      </span>
+      <span
+        className="text-sm"
+        style={{ color: 'var(--md-on-surface-variant)' }}
+      >
+        {text}
+      </span>
+    </div>
+  )
+}
+
+function FeatureCard({
+  icon,
+  title,
+  description,
+}: {
+  icon: string
+  title: string
+  description: string
+}) {
+  return (
+    <div
+      className="p-5 rounded-2xl shadow-lg"
+      style={{
+        background: 'var(--md-surface-container)',
+        border: '1px solid var(--md-outline-variant)',
+      }}
+    >
+      <div className="flex items-start gap-4">
+        <div
+          className="w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0"
+          style={{
+            background: 'var(--md-primary-container)',
+          }}
+        >
+          <span
+            className="material-symbols-outlined text-2xl"
+            style={{ color: 'var(--md-primary)' }}
+          >
+            {icon}
+          </span>
+        </div>
+        <div>
+          <h3
+            className="font-semibold text-base mb-1"
+            style={{ color: 'var(--md-on-surface)' }}
+          >
+            {title}
+          </h3>
+          <p
+            className="text-sm"
+            style={{ color: 'var(--md-on-surface-variant)' }}
+          >
+            {description}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function IntegrationCard({
+  icon,
+  title,
+  description,
+}: {
+  icon: string
+  title: string
+  description: string
+}) {
+  return (
+    <div
+      className="p-6 rounded-2xl"
+      style={{
+        background: 'var(--md-surface)',
+        border: '1px solid var(--md-outline-variant)',
+      }}
+    >
+      <div
+        className="w-12 h-12 rounded-xl flex items-center justify-center mb-4"
+        style={{ background: 'var(--md-primary-container)' }}
+      >
+        <span
+          className="material-symbols-outlined text-2xl"
+          style={{ color: 'var(--md-primary)' }}
+        >
+          {icon}
+        </span>
+      </div>
+      <h3
+        className="font-semibold text-lg mb-2"
+        style={{ color: 'var(--md-on-surface)' }}
+      >
+        {title}
+      </h3>
+      <p
+        className="text-sm"
+        style={{ color: 'var(--md-on-surface-variant)' }}
+      >
+        {description}
+      </p>
+    </div>
+  )
+}

--- a/components/auth/AuthLayout.tsx
+++ b/components/auth/AuthLayout.tsx
@@ -1,0 +1,224 @@
+"use client"
+
+import Image from "next/image"
+import Link from "next/link"
+import { ThemeSwitch } from "@/components/ThemeSwitch"
+import { useTheme } from "@/lib/theme"
+
+interface AuthLayoutProps {
+  children: React.ReactNode
+  /** Optional testimonial to display */
+  testimonial?: {
+    quote: string
+    author: string
+    role: string
+    avatar?: string
+  }
+}
+
+/**
+ * Split-screen auth layout inspired by Nexus design pattern
+ * Features:
+ * - Left side: Illustration with testimonial overlay (hidden on mobile)
+ * - Right side: Form content with logo and theme toggle
+ * - Fully themable using CSS variables
+ */
+export function AuthLayout({ children, testimonial }: AuthLayoutProps) {
+  const { currentTheme } = useTheme()
+  const isDark = currentTheme.mode === "dark"
+
+  const defaultTestimonial = {
+    quote: "TheBridge transformed our incident response. AI-driven insights have never been this intuitive!",
+    author: "Jason Ihaia",
+    role: "VP Engineering",
+    avatar: undefined,
+  }
+
+  const displayTestimonial = testimonial || defaultTestimonial
+
+  return (
+    <div className="min-h-screen flex bg-[var(--md-surface)]">
+      {/* Left Side: Illustration and Testimonial */}
+      <div
+        className="hidden lg:flex lg:w-1/2 relative items-center justify-center p-12"
+        style={{
+          background: `linear-gradient(135deg,
+            var(--md-primary-container) 0%,
+            var(--md-secondary-container) 50%,
+            var(--md-tertiary-container) 100%)`
+        }}
+      >
+        {/* Decorative background pattern */}
+        <div
+          className="absolute inset-0 opacity-10"
+          style={{
+            backgroundImage: `radial-gradient(circle at 25px 25px, var(--md-on-surface) 2px, transparent 0)`,
+            backgroundSize: '50px 50px',
+          }}
+        />
+
+        {/* Main content container */}
+        <div className="relative w-full max-w-xl flex flex-col items-center justify-center">
+          {/* Large logo or illustration */}
+          <div className="mb-8">
+            <Image
+              src={isDark ? "/thebridge-logo-dark.svg" : "/thebridge-logo-light.svg"}
+              alt="TheBridge"
+              width={240}
+              height={70}
+              priority
+              className="h-16 w-auto"
+            />
+          </div>
+
+          {/* Feature highlights */}
+          <div className="space-y-4 mb-8">
+            <FeatureItem
+              icon="monitoring"
+              title="Unified Observability"
+              description="Connect all your monitoring tools in one place"
+            />
+            <FeatureItem
+              icon="psychology"
+              title="AI-Powered Insights"
+              description="Let AI agents analyze incidents and suggest fixes"
+            />
+            <FeatureItem
+              icon="speed"
+              title="Faster Resolution"
+              description="Reduce MTTR with intelligent automation"
+            />
+          </div>
+
+          {/* Testimonial Card */}
+          <div
+            className="w-full max-w-md p-6 rounded-2xl shadow-xl"
+            style={{
+              background: 'var(--md-surface-container)',
+              border: '1px solid var(--md-outline-variant)',
+            }}
+          >
+            <div className="flex items-center gap-3 mb-4">
+              {/* Avatar */}
+              <div
+                className="w-12 h-12 rounded-full flex items-center justify-center text-lg font-semibold"
+                style={{
+                  background: 'linear-gradient(135deg, var(--md-primary), var(--md-secondary))',
+                  color: 'var(--md-on-primary)',
+                }}
+              >
+                {displayTestimonial.author.split(' ').map(n => n[0]).join('').slice(0, 2)}
+              </div>
+              <div className="flex-1">
+                <p
+                  className="font-semibold text-sm"
+                  style={{ color: 'var(--md-on-surface)' }}
+                >
+                  {displayTestimonial.author}
+                </p>
+                <p
+                  className="text-xs"
+                  style={{ color: 'var(--md-on-surface-variant)' }}
+                >
+                  {displayTestimonial.role}
+                </p>
+              </div>
+              {/* Star rating */}
+              <div className="flex gap-0.5">
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <span
+                    key={star}
+                    className="material-symbols-outlined text-sm"
+                    style={{
+                      color: 'var(--md-warning)',
+                      fontVariationSettings: "'FILL' 1",
+                    }}
+                  >
+                    star
+                  </span>
+                ))}
+              </div>
+            </div>
+            <p
+              className="text-sm leading-relaxed"
+              style={{ color: 'var(--md-on-surface-variant)' }}
+            >
+              &ldquo;{displayTestimonial.quote}&rdquo;
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Right Side: Form Content */}
+      <div
+        className="w-full lg:w-1/2 flex items-center justify-center p-6 lg:p-12"
+        style={{ background: 'var(--md-surface)' }}
+      >
+        <div className="w-full max-w-md">
+          {/* Header with Logo and Theme Toggle */}
+          <div className="flex items-center justify-between mb-12">
+            <Link href="/" className="hover:opacity-80 transition-opacity">
+              <Image
+                src={isDark ? "/thebridge-logo-dark.svg" : "/thebridge-logo-light.svg"}
+                alt="TheBridge"
+                width={140}
+                height={40}
+                priority
+                className="h-10 w-auto"
+              />
+            </Link>
+
+            <ThemeSwitch />
+          </div>
+
+          {/* Main Form Content */}
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Feature item for the left panel */
+function FeatureItem({
+  icon,
+  title,
+  description
+}: {
+  icon: string
+  title: string
+  description: string
+}) {
+  return (
+    <div className="flex items-start gap-4">
+      <div
+        className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+        style={{
+          background: 'var(--md-surface-container)',
+          border: '1px solid var(--md-outline-variant)',
+        }}
+      >
+        <span
+          className="material-symbols-outlined text-xl"
+          style={{ color: 'var(--md-primary)' }}
+        >
+          {icon}
+        </span>
+      </div>
+      <div>
+        <h3
+          className="font-semibold text-sm"
+          style={{ color: 'var(--md-on-surface)' }}
+        >
+          {title}
+        </h3>
+        <p
+          className="text-xs"
+          style={{ color: 'var(--md-on-surface-variant)' }}
+        >
+          {description}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/auth/index.ts
+++ b/components/auth/index.ts
@@ -1,2 +1,3 @@
+export { AuthLayout } from "./AuthLayout"
 export { SessionProvider } from "./SessionProvider"
 export { UserMenu } from "./UserMenu"


### PR DESCRIPTION
Closes #34

## Summary
- Add full-screen landing page for unauthenticated users
- Create split-screen AuthLayout component matching thingspaces design
- Update authentication to GitHub-only
- Hide header/footer for logged-out users (they have their own nav)

## Changes Made
- **New Components:**
  - `LandingPage.tsx` - Hero section with features, integrations, and CTAs
  - `AuthLayout.tsx` - Split-screen auth layout with testimonials
  - `AppShell.tsx` - Conditional header/footer wrapper based on auth state
  - `app/auth/layout.tsx` - Special layout for auth pages

- **Updated:**
  - `auth.ts` - Removed Google OAuth, GitHub-only now
  - `app/page.tsx` - Show landing page for logged-out users
  - `app/layout.tsx` - Use AppShell for conditional chrome
  - `app/auth/signin/page.tsx` - Use new AuthLayout, GitHub button
  - `app/auth/error/page.tsx` - Use new AuthLayout

## Features
- Fully themable with CSS variables (no hardcoded colors)
- Dark/light mode support
- Responsive design with mobile-first approach
- Matches thingspaces auth page patterns

## Test Plan
- [ ] Visit `/` when logged out - see landing page
- [ ] Visit `/` when logged in - see chat interface with header/footer
- [ ] Click "Sign In with GitHub" - redirects to GitHub OAuth
- [ ] Visit `/auth/signin` - see split-screen login page
- [ ] Test theme switching on landing page
- [ ] Test mobile responsive layout