### PR TITLE
Add spacing below header on logged out landing page

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -52,7 +52,7 @@ export function LandingPage() {
       </nav>
 
       {/* Hero Section */}
-      <div className="flex-1 flex">
+      <div className="flex-1 flex mt-8 lg:mt-12">
         {/* Left Content */}
         <div className="flex-1 flex flex-col justify-center px-8 lg:px-16 py-12">
           <div className="max-w-xl">


### PR DESCRIPTION
Closes #40

## Summary
Add margin-top spacing between the navigation header and the hero section on the logged out landing page for better visual breathing room.

## Changes Made
- Added `mt-8` (2rem/32px) on mobile
- Added `lg:mt-12` (3rem/48px) on larger screens

This creates visual separation between the header and hero content.