### PR TITLE
Fix sign-in button styling in header

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -35,18 +35,21 @@ export function LandingPage() {
           />
         </Link>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           <ThemeSwitch />
           <button
             onClick={() => signIn("github")}
-            className="px-4 py-2 rounded-lg font-medium text-sm
-              transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full font-medium text-xs
+              transition-all duration-150 hover:opacity-90 active:scale-95"
             style={{
               background: 'var(--md-primary)',
               color: 'var(--md-on-primary)',
             }}
           >
-            Sign In with GitHub
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+              <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+            </svg>
+            Sign In
           </button>
         </div>
       </nav>


### PR DESCRIPTION
Closes #44

## Summary
The sign-in with GitHub button in the landing page header was too large and looked out of place. This PR makes it smaller and more compact to match the overall header styling.

## Changes Made
- Changed button padding from `px-4 py-2` to `px-3 py-1.5` (more compact)
- Changed from `rounded-lg` to `rounded-full` (pill/chip style)
- Reduced font size from `text-sm` to `text-xs`
- Added inline GitHub icon (w-4 h-4) for visual recognition
- Shortened button text from "Sign In with GitHub" to just "Sign In" (icon conveys GitHub)
- Reduced gap between header items from `gap-3` to `gap-2`

The button now has a more refined, compact appearance that fits better with the header design.