### PR TITLE
Fix claude-implement workflow trigger condition

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -10,10 +10,12 @@ on:
 jobs:
   implement:
     # Only run if:
-    # 1. Issue has 'claude-implement' label, OR
-    # 2. Comment contains @claude mention
+    # 1. Issue is opened with 'claude-implement' label already present, OR
+    # 2. The 'claude-implement' label was just added (labeled event), OR
+    # 3. Comment contains @claude mention
     if: |
-      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'claude-implement')) ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'claude-implement')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'claude-implement') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
The `claude-implement` workflow was being skipped even when the `claude-triage` workflow added the `claude-implement` label. This was because the workflow condition was checking `github.event.issue.labels` which doesn't reflect labels added during the `labeled` event.

## Problem
When triage adds the `claude-implement` label:
1. GitHub fires a `labeled` event
2. The implement workflow starts
3. BUT `github.event.issue.labels` contains labels from BEFORE the label was added
4. The condition `contains(github.event.issue.labels.*.name, 'claude-implement')` fails
5. Workflow is skipped

## Solution
For `labeled` events, check `github.event.label.name` instead, which contains the name of the label that was just added.

```yaml
# Before (broken)
contains(github.event.issue.labels.*.name, 'claude-implement')

# After (works)
github.event.label.name == 'claude-implement'
```

## Changes
- Split the condition to handle `opened` and `labeled` events separately
- `opened`: Check if issue already has the label (for issues created with label)
- `labeled`: Check if the label being added is `claude-implement`
- `issue_comment`: Check for @claude mention (unchanged)