### PR TITLE
Add both claude labels to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.yml
+++ b/.github/ISSUE_TEMPLATE/default.yml
@@ -1,7 +1,7 @@
 name: Issue
 description: Create a new issue
 title: "[Issue]: "
-labels: ["claude-triage"]
+labels: ["claude-triage", "claude-implement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Closes #50

## Summary
Updated the GitHub issue template to automatically apply both claude labels (`claude-triage` and `claude-implement`) to all new issues.

## Changes Made
- Modified `.github/ISSUE_TEMPLATE/default.yml` to include both labels
- New issues will now trigger the auto-implementation workflow automatically

## Before
```yaml
labels: ["claude-triage"]
```

## After
```yaml
labels: ["claude-triage", "claude-implement"]
```