### PR TITLE
Add Code link next to Verbose button

### DIFF
--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import TokenBudgetDisplay from './TokenBudgetDisplay';
 import QueryOptimizer from './QueryOptimizer';
@@ -814,6 +815,14 @@ const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(functi
         >
           {verbose ? '✓ Verbose' : 'Verbose'}
         </button>
+        <span className="text-[var(--md-outline-variant)]">|</span>
+        <Link
+          href="/code"
+          className="text-xs text-[var(--md-on-surface-variant)] hover:text-[var(--md-on-surface)] transition-colors duration-200"
+          title="View code examples"
+        >
+          Code
+        </Link>
         <span className="text-[var(--md-outline-variant)]">|</span>
         <button
           type="button"


### PR DESCRIPTION
Closes #67

## Summary
Added a "Code" link to the right of the "Verbose" button that navigates to the /code route.

## Changes Made
- Added Link import from next/link to ChatInterface component
- Added Code link element with consistent styling
- Positioned between Verbose button and Optimize button with proper separators
- Applied same hover and color transition styles as other UI elements

## Technical Details
- Uses Next.js Link component for client-side navigation
- Follows existing UI patterns for text links in the control bar
- Maintains Material Design color variables for consistency