### PR TITLE
Fix logged-out landing page scrolling

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -16,7 +16,7 @@ export function LandingPage() {
 
   return (
     <div
-      className="min-h-screen flex flex-col"
+      className="min-h-screen flex flex-col overflow-y-auto"
       style={{ background: 'var(--md-surface)' }}
     >
       {/* Navigation */}
@@ -55,7 +55,7 @@ export function LandingPage() {
       </nav>
 
       {/* Hero Section */}
-      <div className="flex-1 flex mt-8 lg:mt-12">
+      <div className="flex flex-col lg:flex-row mt-8 lg:mt-12">
         {/* Left Content */}
         <div className="flex-1 flex flex-col justify-center px-8 lg:px-16 py-12">
           <div className="max-w-xl">


### PR DESCRIPTION
Closes #66

## Summary
Fixed the scrolling issue on the logged-out landing page where content at the bottom was cut off and inaccessible.

## Changes Made
- Added `overflow-y-auto` to the root container div to enable vertical scrolling
- Changed hero section from `flex-1 flex` to `flex flex-col lg:flex-row` to remove fixed height constraint
- Ensured all content (features section, footer) is now accessible via scroll

## Root Cause
The landing page container was using `flex-1` on the hero section which tried to fit everything within the viewport height without allowing overflow. This prevented users from scrolling down to see the features section and footer.

## Testing
- Content is now accessible by scrolling
- Layout remains responsive on mobile and desktop
- No visual regressions in the header or hero sections