### PR TITLE
Fix: npx @thebridge/local start error

### DIFF
--- a/packages/local-bridge/package.json
+++ b/packages/local-bridge/package.json
@@ -4,7 +4,8 @@
   "description": "Local bridge server for TheBridge - enables local coding capabilities",
   "main": "dist/index.js",
   "bin": {
-    "thebridge-local": "./dist/cli.js"
+    "thebridge-local": "./dist/cli.js",
+    "local": "./dist/cli.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Closes #72

## Summary
Fixed the issue where running `npx @thebridge/local start` would fail because the package.json only had a `thebridge-local` bin entry, but npx looks for a bin entry matching the package name (without scope).

## Changes Made
- Added `local` bin entry to package.json alongside `thebridge-local`
- This supports both usage patterns:
  - `npx @thebridge/local start` (uses `local` bin entry)
  - `thebridge-local start` (uses `thebridge-local` bin entry after global install)

## Technical Details
When using npx with a scoped package like `@thebridge/local`, npx looks for a bin entry that matches the package name without the scope (i.e., `local`). Without this entry, npx doesn't know which command to execute, resulting in an error.

## Test Plan
- [x] Added `local` bin entry to package.json
- [ ] Users can now run `npx @thebridge/local start` successfully
- [ ] Global install still works with `thebridge-local start`