### PR TITLE
Fix project deprecation warning

### DIFF
--- a/.github/KNOWN_ISSUES.md
+++ b/.github/KNOWN_ISSUES.md
@@ -1,0 +1,48 @@
+# Known Issues
+
+This document tracks known issues that are outside of our direct control or are being monitored.
+
+## GitHub CLI - Projects (Classic) Deprecation Warning
+
+**Status**: Monitoring upstream fix
+**Severity**: Low (cosmetic warning only)
+**Issue**: [#71](https://github.com/tunacasserole/thebridge/issues/71)
+
+### Description
+
+When using the GitHub CLI (`gh`) commands, especially `gh pr` operations, you may see this deprecation warning:
+
+```
+GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience,
+see: https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/.
+(repository.pullRequest.projectCards)
+```
+
+### Root Cause
+
+This warning originates from the GitHub CLI tool itself, not from TheBridge code. The `gh` CLI internally queries the deprecated `repository.pullRequest.projectCards` GraphQL field when fetching pull request information.
+
+### Impact
+
+- **Functional**: None - all PR operations work correctly
+- **Visual**: Warning message appears in terminal output
+- **Action Required**: None from TheBridge maintainers
+
+### Resolution
+
+This will be resolved when:
+1. GitHub completes their migration to the new Projects API
+2. The GitHub CLI team updates `gh` to use the new Projects API endpoints
+
+### Tracking
+
+- GitHub Projects Classic sunset notice: https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/
+- GitHub CLI issue tracker: https://github.com/cli/cli/issues
+
+### Workarounds
+
+None needed. The warning can be safely ignored as it does not affect functionality.
+
+---
+
+Last Updated: 2025-12-16


### PR DESCRIPTION
Closes #71

## Summary
Documents the GitHub Projects (classic) deprecation warning that appears when using GitHub CLI commands. This is an upstream issue in the `gh` CLI tool itself, not in TheBridge code.

## Analysis
After thorough investigation, the deprecation warning originates from:
- The GitHub CLI tool (`gh`) internally querying the deprecated `repository.pullRequest.projectCards` GraphQL field
- No TheBridge code directly uses the deprecated Projects (classic) API
- The warning appears during `gh pr` operations but does not affect functionality

## Changes Made
- Created `.github/KNOWN_ISSUES.md` to document this and future upstream issues
- Documented the root cause, impact, and resolution timeline
- Provided tracking links to GitHub's sunset notice and CLI issue tracker

## Impact
- **Functional**: None - all operations work correctly
- **Visual**: Warning message can be safely ignored
- **Resolution**: Will be fixed upstream when GitHub CLI updates to new Projects API