### PR TITLE
Token Counter

### DIFF
--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -7,6 +7,7 @@ import TokenBudgetDisplay from './TokenBudgetDisplay';
 import QueryOptimizer from './QueryOptimizer';
 import ResponseModeSelector, { useResponseMode, type ResponseMode } from './ResponseModeSelector';
 import TokenUsageFeedback from './TokenUsageFeedback';
+import ConversationTokenCounter from './ConversationTokenCounter';
 
 interface FileAttachment {
   name: string;
@@ -883,8 +884,15 @@ const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(functi
       {/* Messages State */}
       {hasMessages && (
         <div className="flex flex-col flex-1 min-h-0">
+          {/* Token counter - fixed at top right */}
+          <div className="sticky top-0 z-10 flex justify-end px-4 pt-3 pb-2 bg-gradient-to-b from-[var(--md-surface)] to-transparent pointer-events-none">
+            <div className="pointer-events-auto">
+              <ConversationTokenCounter messages={messages} />
+            </div>
+          </div>
+
           {/* Scrollable messages area */}
-          <div className="flex-1 overflow-y-auto px-4 pt-6 min-h-0">
+          <div className="flex-1 overflow-y-auto px-4 min-h-0">
             {error && (
               <div className="py-2 mb-4 bg-[var(--md-warning-container)] border border-[var(--md-warning)] rounded-lg">
                 <p className="text-xs text-[var(--md-on-warning-container)] px-4">

--- a/components/ConversationTokenCounter.tsx
+++ b/components/ConversationTokenCounter.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useMemo } from 'react';
+
+interface Message {
+  content: string;
+  role: 'user' | 'assistant';
+  toolCalls?: unknown[];
+}
+
+interface ConversationTokenCounterProps {
+  messages: Message[];
+  className?: string;
+}
+
+/**
+ * Estimates token count for a text string
+ * Using a simple approximation: 1 token ≈ 4 characters
+ * This is a rough estimate but works well for Claude models
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export default function ConversationTokenCounter({
+  messages,
+  className = '',
+}: ConversationTokenCounterProps) {
+  const totalTokens = useMemo(() => {
+    return messages.reduce((sum, message) => {
+      // Count message content tokens
+      const contentTokens = estimateTokens(message.content);
+
+      // Add a small overhead for tool calls (rough estimate)
+      const toolTokens = message.toolCalls ? message.toolCalls.length * 10 : 0;
+
+      return sum + contentTokens + toolTokens;
+    }, 0);
+  }, [messages]);
+
+  // Don't show if there are no messages
+  if (messages.length === 0) {
+    return null;
+  }
+
+  // Format number with commas for readability
+  const formattedTokens = totalTokens.toLocaleString();
+
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-[var(--md-surface-container)] border border-[var(--md-outline-variant)] ${className}`}
+      title="Estimated tokens in this conversation"
+    >
+      <svg
+        className="w-3.5 h-3.5 text-[var(--md-on-surface-variant)]"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+        />
+      </svg>
+      <span className="text-xs font-mono text-[var(--md-on-surface-variant)]">
+        ~{formattedTokens}
+      </span>
+      <span className="text-[9px] text-[var(--md-on-surface-variant)] opacity-70">
+        tokens
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #73

## Summary
Added a conversation token counter that displays the estimated number of tokens in each chat conversation. The counter appears in the top-right corner of the chat window and updates in real-time as messages are added.

## Changes Made
- Created `ConversationTokenCounter` component with token estimation logic
- Integrated counter into `ChatInterface` component
- Used character-based approximation (1 token ≈ 4 characters) for token counting
- Added visual design with document icon and formatted numbers
- Counter is sticky-positioned at top-right for easy visibility

## Technical Details
- Token estimation uses `chars / 4` approximation (standard for Claude models)
- Accounts for both message content and tool call overhead
- Real-time updates via React useMemo hook
- Unobtrusive design that doesn't interfere with chat flow
- Shows format like "~1,234 tokens" with thousands separators

## UI/UX
- Small badge in top-right corner of chat window
- Sticky positioning so it's always visible while scrolling
- Tooltip explains it's an estimated count
- Only appears when there are messages in the conversation