### PR TITLE
feat: Add Learn Mode with radial FAB navigation

### DIFF
--- a/app/api/lessons/[id]/route.ts
+++ b/app/api/lessons/[id]/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/lessons/[id]
+ * Returns a single lesson by ID with full content
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+
+    const lesson = await prisma.lesson.findUnique({
+      where: { id },
+    });
+
+    if (!lesson) {
+      return NextResponse.json(
+        { error: 'Lesson not found' },
+        { status: 404 }
+      );
+    }
+
+    if (!lesson.isPublished) {
+      return NextResponse.json(
+        { error: 'Lesson not published' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(lesson);
+  } catch (error) {
+    console.error('[Lessons API] Error fetching lesson:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch lesson' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/lessons/[id]
+ * Update a lesson (admin only in future)
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { name, content, sortOrder, isPublished } = body;
+
+    const lesson = await prisma.lesson.update({
+      where: { id },
+      data: {
+        ...(name !== undefined && { name }),
+        ...(content !== undefined && { content }),
+        ...(sortOrder !== undefined && { sortOrder }),
+        ...(isPublished !== undefined && { isPublished }),
+      },
+    });
+
+    return NextResponse.json(lesson);
+  } catch (error) {
+    console.error('[Lessons API] Error updating lesson:', error);
+    return NextResponse.json(
+      { error: 'Failed to update lesson' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/lessons/[id]
+ * Delete a lesson (admin only in future)
+ */
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+
+    await prisma.lesson.delete({
+      where: { id },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[Lessons API] Error deleting lesson:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete lesson' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/lessons/route.ts
+++ b/app/api/lessons/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+
+/**
+ * GET /api/lessons
+ * Returns all published lessons ordered by sortOrder
+ */
+export async function GET() {
+  try {
+    const lessons = await prisma.lesson.findMany({
+      where: { isPublished: true },
+      orderBy: { sortOrder: 'asc' },
+      select: {
+        id: true,
+        name: true,
+        sortOrder: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return NextResponse.json(lessons);
+  } catch (error) {
+    console.error('[Lessons API] Error fetching lessons:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch lessons' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/lessons
+ * Create a new lesson (admin only in future)
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { name, content, sortOrder } = body;
+
+    if (!name || !content) {
+      return NextResponse.json(
+        { error: 'Name and content are required' },
+        { status: 400 }
+      );
+    }
+
+    const lesson = await prisma.lesson.create({
+      data: {
+        name,
+        content,
+        sortOrder: sortOrder ?? 0,
+      },
+    });
+
+    return NextResponse.json(lesson, { status: 201 });
+  } catch (error) {
+    console.error('[Lessons API] Error creating lesson:', error);
+    return NextResponse.json(
+      { error: 'Failed to create lesson' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/lib/theme";
 import { RoleProvider } from "@/contexts/RoleContext";
 import { MultiAgentProvider } from "@/contexts/MultiAgentContext";
 import { DashboardProvider } from "@/contexts/DashboardContext";
+import { LearnProvider } from "@/contexts/LearnContext";
 import { SessionProvider } from "@/components/auth";
 import { LocalBridgeProvider } from "@/contexts/LocalBridgeContext";
 
@@ -48,11 +49,13 @@ export default function RootLayout({
             <RoleProvider>
               <MultiAgentProvider>
                 <DashboardProvider>
-                  <LocalBridgeProvider>
-                    <AppShell>
-                      {children}
-                    </AppShell>
-                  </LocalBridgeProvider>
+                  <LearnProvider>
+                    <LocalBridgeProvider>
+                      <AppShell>
+                        {children}
+                      </AppShell>
+                    </LocalBridgeProvider>
+                  </LearnProvider>
                 </DashboardProvider>
               </MultiAgentProvider>
             </RoleProvider>

--- a/components/LearnSidebar.tsx
+++ b/components/LearnSidebar.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useLearn, type LessonSummary } from '@/contexts/LearnContext';
+
+interface LearnSidebarProps {
+  mode?: 'full' | 'mini';
+  onToggleMode?: () => void;
+}
+
+function LessonItem({ lesson, isSelected, onClick }: {
+  lesson: LessonSummary;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        w-full group flex items-center gap-3 px-3 py-2.5 rounded-xl transition-all duration-200 text-left relative
+        hover:bg-[var(--md-surface-container-high)]
+        ${isSelected
+          ? 'bg-[var(--md-surface-container)]'
+          : ''
+        }
+      `}
+      style={{
+        backgroundColor: isSelected ? 'rgba(166, 124, 82, 0.12)' : undefined,
+        borderLeft: isSelected ? '3px solid #a67c52' : '3px solid transparent',
+      }}
+    >
+      {/* Book Icon */}
+      <div
+        className={`
+          flex items-center justify-center w-9 h-9 rounded-lg transition-colors
+          ${isSelected
+            ? 'text-[#a67c52]'
+            : 'bg-[var(--md-surface-container)] text-[var(--md-on-surface-variant)] group-hover:bg-[var(--md-surface-container-high)]'
+          }
+        `}
+        style={{
+          backgroundColor: isSelected ? 'rgba(166, 124, 82, 0.15)' : undefined,
+        }}
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+        </svg>
+      </div>
+
+      {/* Lesson Name */}
+      <div className="flex-1 min-w-0">
+        <p
+          className={`
+            text-sm font-medium truncate
+            ${isSelected
+              ? 'text-[#a67c52]'
+              : 'text-[var(--md-on-surface)]'
+            }
+          `}
+        >
+          {lesson.name}
+        </p>
+      </div>
+
+      {/* Selection indicator */}
+      {isSelected && (
+        <div
+          className="w-2 h-2 rounded-full flex-shrink-0"
+          style={{ backgroundColor: '#a67c52' }}
+        />
+      )}
+    </button>
+  );
+}
+
+function LessonSkeleton() {
+  return (
+    <div className="w-full flex items-center gap-3 px-3 py-2.5 animate-pulse">
+      <div className="w-9 h-9 rounded-lg bg-[var(--md-surface-container-high)]" />
+      <div className="flex-1">
+        <div className="h-4 w-3/4 rounded bg-[var(--md-surface-container-high)]" />
+      </div>
+    </div>
+  );
+}
+
+export default function LearnSidebar({ mode = 'full', onToggleMode }: LearnSidebarProps) {
+  const { lessons, currentLessonId, isLoadingLessons, error, selectLesson, refreshLessons } = useLearn();
+  const isMiniMode = mode === 'mini';
+
+  return (
+    <aside className={`${isMiniMode ? 'w-14' : 'w-64'} h-full flex-shrink-0 border-r border-[var(--md-outline-variant)] bg-[var(--md-surface)] flex flex-col overflow-hidden relative transition-all duration-300`}>
+      <div className={`${isMiniMode ? 'p-1' : 'p-3'} flex-1 space-y-4 overflow-y-auto`}>
+        {/* Lessons Header */}
+        {!isMiniMode && (
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2">
+              <h2 className="text-[10px] font-semibold uppercase tracking-wider text-[var(--md-on-surface-variant)]">
+                Lessons
+              </h2>
+              <span
+                className="text-[10px] font-medium px-1.5 py-0.5 rounded-full"
+                style={{
+                  backgroundColor: 'rgba(166, 124, 82, 0.15)',
+                  color: '#a67c52',
+                }}
+              >
+                {lessons.length}
+              </span>
+            </div>
+            {/* Refresh button */}
+            <button
+              onClick={() => refreshLessons()}
+              className="p-1 rounded transition-colors hover:bg-[var(--md-surface-container-high)]"
+              title="Refresh lessons"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                className="w-3.5 h-3.5 text-[var(--md-on-surface-variant)]"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          </div>
+        )}
+
+        {/* Lessons List */}
+        <div className="space-y-1">
+          {isLoadingLessons ? (
+            // Loading skeletons
+            <>
+              <LessonSkeleton />
+              <LessonSkeleton />
+              <LessonSkeleton />
+            </>
+          ) : error ? (
+            // Error state
+            <div className="px-3 py-4 text-center">
+              <p className="text-sm text-[var(--md-error)]">{error}</p>
+              <button
+                onClick={() => refreshLessons()}
+                className="mt-2 text-xs text-[var(--md-primary)] hover:underline"
+              >
+                Try again
+              </button>
+            </div>
+          ) : lessons.length === 0 ? (
+            // Empty state
+            <div className="px-3 py-8 text-center">
+              <div
+                className="w-12 h-12 mx-auto mb-3 rounded-full flex items-center justify-center"
+                style={{ backgroundColor: 'rgba(166, 124, 82, 0.1)' }}
+              >
+                <svg className="w-6 h-6" style={{ color: '#a67c52' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                </svg>
+              </div>
+              <p className="text-sm text-[var(--md-on-surface-variant)]">
+                No lessons available
+              </p>
+              <p className="text-xs text-[var(--md-on-surface-variant)] opacity-70 mt-1">
+                Lessons will appear here once added
+              </p>
+            </div>
+          ) : (
+            // Lessons list
+            lessons.map((lesson) => (
+              isMiniMode ? (
+                // Mini mode: icon only
+                <button
+                  key={lesson.id}
+                  onClick={() => selectLesson(lesson.id)}
+                  className="w-full flex items-center justify-center p-1.5 rounded-lg transition-all duration-200 hover:bg-[var(--md-surface-container)]"
+                  style={{
+                    backgroundColor: currentLessonId === lesson.id ? 'rgba(166, 124, 82, 0.12)' : 'transparent',
+                  }}
+                  title={lesson.name}
+                >
+                  <div
+                    className="flex items-center justify-center w-8 h-8 rounded-full transition-colors [&>svg]:w-5 [&>svg]:h-5"
+                    style={{
+                      background: currentLessonId === lesson.id ? 'rgba(166, 124, 82, 0.15)' : 'var(--md-surface-container-high)',
+                      color: currentLessonId === lesson.id ? '#a67c52' : 'var(--md-on-surface-variant)',
+                      border: currentLessonId === lesson.id ? '1.5px solid rgba(166, 124, 82, 0.5)' : '1.5px solid transparent',
+                    }}
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                    </svg>
+                  </div>
+                </button>
+              ) : (
+                <LessonItem
+                  key={lesson.id}
+                  lesson={lesson}
+                  isSelected={currentLessonId === lesson.id}
+                  onClick={() => selectLesson(lesson.id)}
+                />
+              )
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Footer with toggle button */}
+      <div className={`flex-shrink-0 border-t border-[var(--md-outline-variant)] ${isMiniMode ? 'p-2' : 'px-3 py-2'}`}>
+        <div className={`flex items-center ${isMiniMode ? 'justify-center' : 'justify-between'}`}>
+          {!isMiniMode && (
+            <span
+              className="text-[10px] font-medium px-2 py-0.5 rounded-full"
+              style={{
+                background: 'rgba(166, 124, 82, 0.15)',
+                color: '#a67c52',
+              }}
+            >
+              Learn Mode
+            </span>
+          )}
+          {/* Toggle Button */}
+          <button
+            onClick={onToggleMode}
+            className={`
+              flex items-center justify-center rounded-lg transition-colors
+              hover:bg-[var(--md-surface-container-high)]
+              ${isMiniMode ? 'w-full h-8' : 'w-8 h-8'}
+            `}
+            title={isMiniMode ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              className={`w-4 h-4 text-[var(--md-on-surface-variant)] transition-transform duration-300 ${
+                isMiniMode ? 'rotate-180' : ''
+              }`}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M11 19l-7-7 7-7M18 19l-7-7 7-7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/components/LessonContent.tsx
+++ b/components/LessonContent.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import { useLearn } from '@/contexts/LearnContext';
+
+function LessonSkeleton() {
+  return (
+    <div className="max-w-4xl mx-auto animate-pulse">
+      {/* Title skeleton */}
+      <div className="mb-8">
+        <div className="h-10 w-2/3 rounded bg-[var(--md-surface-container-high)] mb-3" />
+        <div className="h-4 w-1/3 rounded bg-[var(--md-surface-container)] " />
+      </div>
+
+      {/* Content skeleton */}
+      <div className="space-y-4">
+        <div className="h-4 w-full rounded bg-[var(--md-surface-container)]" />
+        <div className="h-4 w-5/6 rounded bg-[var(--md-surface-container)]" />
+        <div className="h-4 w-4/5 rounded bg-[var(--md-surface-container)]" />
+        <div className="h-20 w-full rounded bg-[var(--md-surface-container-high)] mt-6" />
+        <div className="h-4 w-full rounded bg-[var(--md-surface-container)]" />
+        <div className="h-4 w-3/4 rounded bg-[var(--md-surface-container)]" />
+      </div>
+    </div>
+  );
+}
+
+function WelcomeState() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center px-8">
+      {/* Book illustration */}
+      <div
+        className="w-24 h-24 rounded-full flex items-center justify-center mb-6"
+        style={{ backgroundColor: 'rgba(166, 124, 82, 0.1)' }}
+      >
+        <svg
+          className="w-12 h-12"
+          style={{ color: '#a67c52' }}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+          />
+        </svg>
+      </div>
+
+      <h2
+        className="text-2xl font-semibold mb-3"
+        style={{ color: '#a67c52' }}
+      >
+        Welcome to Learn Mode
+      </h2>
+
+      <p className="text-[var(--md-on-surface-variant)] max-w-md mb-6">
+        Select a lesson from the sidebar to start learning. Each lesson contains
+        detailed information to help you master SRE concepts and tools.
+      </p>
+
+      <div className="flex items-center gap-2 text-sm text-[var(--md-on-surface-variant)] opacity-70">
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        <span>Select a lesson from the sidebar</span>
+      </div>
+    </div>
+  );
+}
+
+export default function LessonContent() {
+  const { currentLesson, isLoadingContent, error } = useLearn();
+
+  // Loading state
+  if (isLoadingContent) {
+    return (
+      <div className="flex-1 p-8 overflow-y-auto bg-[var(--md-surface)]">
+        <LessonSkeleton />
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center bg-[var(--md-surface)]">
+        <div className="text-center px-8">
+          <div
+            className="w-16 h-16 mx-auto mb-4 rounded-full flex items-center justify-center"
+            style={{ backgroundColor: 'rgba(239, 68, 68, 0.1)' }}
+          >
+            <svg className="w-8 h-8 text-[var(--md-error)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <p className="text-lg font-medium text-[var(--md-error)] mb-2">
+            Failed to load lesson
+          </p>
+          <p className="text-sm text-[var(--md-on-surface-variant)]">
+            {error}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // No lesson selected - welcome state
+  if (!currentLesson) {
+    return (
+      <div className="flex-1 bg-[var(--md-surface)]">
+        <WelcomeState />
+      </div>
+    );
+  }
+
+  // Lesson content
+  return (
+    <div className="flex-1 overflow-y-auto bg-[var(--md-surface)]">
+      <div className="max-w-4xl mx-auto px-8 py-8">
+        {/* Lesson Header */}
+        <header className="mb-8 pb-6 border-b border-[var(--md-outline-variant)]">
+          <h1
+            className="text-3xl font-bold mb-2"
+            style={{ color: '#a67c52' }}
+          >
+            {currentLesson.name}
+          </h1>
+          <p className="text-sm text-[var(--md-on-surface-variant)]">
+            Last updated: {new Date(currentLesson.updatedAt).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </p>
+        </header>
+
+        {/* Lesson Content - Markdown */}
+        <article
+          className="
+            prose prose-slate dark:prose-invert max-w-none
+            prose-headings:font-semibold
+            prose-h1:text-2xl prose-h1:mb-4 prose-h1:mt-8
+            prose-h2:text-xl prose-h2:mb-3 prose-h2:mt-6
+            prose-h3:text-lg prose-h3:mb-2 prose-h3:mt-4
+            prose-p:text-[var(--md-on-surface)] prose-p:leading-relaxed prose-p:mb-4
+            prose-a:text-[#a67c52] prose-a:no-underline hover:prose-a:underline
+            prose-strong:text-[var(--md-on-surface)] prose-strong:font-semibold
+            prose-em:text-[var(--md-on-surface-variant)]
+            prose-code:bg-[var(--md-surface-container-high)] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-normal prose-code:before:content-none prose-code:after:content-none
+            prose-pre:bg-[var(--md-surface-container-highest)] prose-pre:p-4 prose-pre:rounded-lg prose-pre:overflow-x-auto prose-pre:my-4
+            prose-ul:my-4 prose-ul:pl-6 prose-li:text-[var(--md-on-surface)] prose-li:my-1
+            prose-ol:my-4 prose-ol:pl-6
+            prose-table:text-sm prose-table:border-collapse prose-table:my-4 prose-table:w-full
+            prose-th:bg-[var(--md-surface-container)] prose-th:px-4 prose-th:py-2 prose-th:text-left prose-th:font-medium prose-th:border prose-th:border-[var(--md-outline-variant)]
+            prose-td:px-4 prose-td:py-2 prose-td:border prose-td:border-[var(--md-outline-variant)]
+            prose-hr:my-6 prose-hr:border-[var(--md-outline-variant)]
+            prose-blockquote:border-l-4 prose-blockquote:pl-4 prose-blockquote:italic prose-blockquote:text-[var(--md-on-surface-variant)] prose-blockquote:my-4
+            prose-img:rounded-lg prose-img:my-4
+            [&>*:first-child]:mt-0 [&>*:last-child]:mb-0
+          "
+          style={{
+            // Override link color with brown theme
+            // @ts-expect-error CSS custom property
+            '--tw-prose-links': '#a67c52',
+          }}
+        >
+          <ReactMarkdown>{currentLesson.content}</ReactMarkdown>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/components/RadialFAB.tsx
+++ b/components/RadialFAB.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import type { ViewMode } from '@/types/views';
+
+interface RadialFABProps {
+  currentMode: ViewMode;
+  onModeChange: (mode: ViewMode) => void;
+}
+
+/**
+ * Mode configurations for the radial FAB
+ * Each mode has a unique color scheme and icon
+ */
+const modeConfigs = {
+  chat: {
+    label: 'Chat',
+    gradient: 'linear-gradient(135deg, #fbbf24, #f59e0b)', // Yellow
+    shadow: '0 4px 20px rgba(251, 191, 36, 0.5)',
+    ring: 'rgba(251, 191, 36, 0.5)',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+      </svg>
+    ),
+  },
+  dashboard: {
+    label: 'Dashboard',
+    gradient: 'linear-gradient(135deg, #f97316, #ea580c)', // Orange
+    shadow: '0 4px 20px rgba(249, 115, 22, 0.5)',
+    ring: 'rgba(249, 115, 22, 0.5)',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+      </svg>
+    ),
+  },
+  learn: {
+    label: 'Learn',
+    gradient: 'linear-gradient(135deg, #a67c52, #8f6641)', // Brown (Mocha theme primary)
+    shadow: '0 4px 20px rgba(166, 124, 82, 0.5)',
+    ring: 'rgba(166, 124, 82, 0.5)',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+      </svg>
+    ),
+  },
+  multiagent: {
+    label: 'Agents',
+    gradient: 'linear-gradient(135deg, #6366f1, #4f46e5)', // Indigo
+    shadow: '0 4px 20px rgba(99, 102, 241, 0.5)',
+    ring: 'rgba(99, 102, 241, 0.5)',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+      </svg>
+    ),
+  },
+};
+
+// Available modes to switch to (excluding multiagent as it's auto-triggered)
+const availableModes: ViewMode[] = ['chat', 'dashboard', 'learn'];
+
+export default function RadialFAB({ currentMode, onModeChange }: RadialFABProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleMainClick = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  const handleModeSelect = useCallback((mode: ViewMode) => {
+    onModeChange(mode);
+    setIsExpanded(false);
+  }, [onModeChange]);
+
+  // Get modes to show in radial (exclude current mode)
+  const otherModes = availableModes.filter((m) => m !== currentMode);
+
+  // Current mode config for the main button
+  const currentConfig = modeConfigs[currentMode] || modeConfigs.chat;
+
+  return (
+    <div className="fixed bottom-9 right-6 z-50">
+      {/* Radial buttons - appear in arc when expanded */}
+      {otherModes.map((mode, index) => {
+        const config = modeConfigs[mode];
+        // Calculate position in an arc (spread 90 degrees from bottom-right)
+        // Start from top-left quadrant relative to main button
+        const totalModes = otherModes.length;
+        const startAngle = 180; // Start from left
+        const endAngle = 270; // End at top
+        const angleStep = (endAngle - startAngle) / (totalModes - 1 || 1);
+        const angle = startAngle + index * angleStep;
+        const radians = (angle * Math.PI) / 180;
+        const distance = 70; // Distance from main button
+        const x = Math.cos(radians) * distance;
+        const y = Math.sin(radians) * distance;
+
+        return (
+          <button
+            key={mode}
+            onClick={() => handleModeSelect(mode)}
+            className={`
+              absolute w-12 h-12 rounded-full
+              flex items-center justify-center
+              transition-all duration-300 ease-out
+              hover:scale-110 active:scale-95
+              focus:outline-none focus:ring-2 focus:ring-offset-2
+              shadow-lg hover:shadow-xl
+              ${isExpanded ? 'opacity-100 scale-100' : 'opacity-0 scale-0 pointer-events-none'}
+            `}
+            style={{
+              background: config.gradient,
+              boxShadow: `${config.shadow}, var(--elevation-2)`,
+              transform: isExpanded
+                ? `translate(${x}px, ${y}px) scale(1)`
+                : 'translate(0, 0) scale(0)',
+              transitionDelay: isExpanded ? `${index * 50}ms` : '0ms',
+              // @ts-expect-error CSS custom property
+              '--tw-ring-color': config.ring,
+              '--tw-ring-offset-color': 'var(--md-surface)',
+            }}
+            aria-label={`Switch to ${config.label}`}
+            title={config.label}
+          >
+            <span className="text-white">{config.icon}</span>
+          </button>
+        );
+      })}
+
+      {/* Main FAB button */}
+      <button
+        onClick={handleMainClick}
+        className={`
+          relative w-14 h-14 rounded-full
+          flex items-center justify-center
+          transition-all duration-300 ease-out
+          hover:scale-110 active:scale-95
+          focus:outline-none focus:ring-2 focus:ring-offset-2
+          shadow-lg hover:shadow-xl
+          ${isExpanded ? 'rotate-45' : 'rotate-0'}
+        `}
+        style={{
+          background: currentConfig.gradient,
+          boxShadow: `${currentConfig.shadow}, var(--elevation-3)`,
+          // @ts-expect-error CSS custom property
+          '--tw-ring-color': currentConfig.ring,
+          '--tw-ring-offset-color': 'var(--md-surface)',
+        }}
+        aria-label={isExpanded ? 'Close mode selector' : `Current mode: ${currentConfig.label}`}
+        title={isExpanded ? 'Close' : currentConfig.label}
+      >
+        <span className="text-white transition-transform duration-300">
+          {isExpanded ? (
+            // Plus icon (rotated to X)
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+          ) : (
+            currentConfig.icon
+          )}
+        </span>
+      </button>
+
+      {/* Backdrop to close when clicking outside */}
+      {isExpanded && (
+        <div
+          className="fixed inset-0 -z-10"
+          onClick={() => setIsExpanded(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/contexts/LearnContext.tsx
+++ b/contexts/LearnContext.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback, useEffect, ReactNode } from 'react';
+
+/**
+ * Lesson summary (from API list endpoint)
+ */
+export interface LessonSummary {
+  id: string;
+  name: string;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Full lesson (from API detail endpoint)
+ */
+export interface Lesson extends LessonSummary {
+  content: string;
+  isPublished: boolean;
+}
+
+interface LearnContextValue {
+  /** List of all available lessons */
+  lessons: LessonSummary[];
+  /** Currently selected lesson (full content) */
+  currentLesson: Lesson | null;
+  /** ID of the currently selected lesson */
+  currentLessonId: string | null;
+  /** Whether lessons are loading */
+  isLoadingLessons: boolean;
+  /** Whether current lesson content is loading */
+  isLoadingContent: boolean;
+  /** Error message if any */
+  error: string | null;
+  /** Select a lesson by ID */
+  selectLesson: (id: string) => void;
+  /** Clear the selected lesson */
+  clearLesson: () => void;
+  /** Refresh the lessons list */
+  refreshLessons: () => Promise<void>;
+}
+
+const LearnContext = createContext<LearnContextValue | null>(null);
+
+export function LearnProvider({ children }: { children: ReactNode }) {
+  const [lessons, setLessons] = useState<LessonSummary[]>([]);
+  const [currentLesson, setCurrentLesson] = useState<Lesson | null>(null);
+  const [currentLessonId, setCurrentLessonId] = useState<string | null>(null);
+  const [isLoadingLessons, setIsLoadingLessons] = useState(true);
+  const [isLoadingContent, setIsLoadingContent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch lessons list
+  const refreshLessons = useCallback(async () => {
+    setIsLoadingLessons(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/lessons');
+      if (!response.ok) {
+        throw new Error('Failed to fetch lessons');
+      }
+      const data = await response.json();
+      setLessons(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load lessons');
+      console.error('[LearnContext] Error fetching lessons:', err);
+    } finally {
+      setIsLoadingLessons(false);
+    }
+  }, []);
+
+  // Load lessons on mount
+  useEffect(() => {
+    refreshLessons();
+  }, [refreshLessons]);
+
+  // Fetch lesson content when selection changes
+  useEffect(() => {
+    if (!currentLessonId) {
+      setCurrentLesson(null);
+      return;
+    }
+
+    const fetchLesson = async () => {
+      setIsLoadingContent(true);
+      setError(null);
+
+      try {
+        const response = await fetch(`/api/lessons/${currentLessonId}`);
+        if (!response.ok) {
+          throw new Error('Failed to fetch lesson');
+        }
+        const data = await response.json();
+        setCurrentLesson(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load lesson');
+        console.error('[LearnContext] Error fetching lesson:', err);
+      } finally {
+        setIsLoadingContent(false);
+      }
+    };
+
+    fetchLesson();
+  }, [currentLessonId]);
+
+  const selectLesson = useCallback((id: string) => {
+    setCurrentLessonId(id);
+  }, []);
+
+  const clearLesson = useCallback(() => {
+    setCurrentLessonId(null);
+    setCurrentLesson(null);
+  }, []);
+
+  return (
+    <LearnContext.Provider
+      value={{
+        lessons,
+        currentLesson,
+        currentLessonId,
+        isLoadingLessons,
+        isLoadingContent,
+        error,
+        selectLesson,
+        clearLesson,
+        refreshLessons,
+      }}
+    >
+      {children}
+    </LearnContext.Provider>
+  );
+}
+
+export function useLearn() {
+  const context = useContext(LearnContext);
+  if (!context) {
+    throw new Error('useLearn must be used within a LearnProvider');
+  }
+  return context;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -243,6 +243,8 @@ model ToolUsageStat {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
   @@unique([userId, toolName])
   @@index([userId])
   @@index([usageCount])
@@ -341,4 +343,21 @@ model UsageSnapshot {
   @@unique([userId, period, periodStart])
   @@index([userId, period])
   @@index([periodStart])
+}
+
+// ============================================
+// Learn Mode - Lessons
+// ============================================
+
+// Lessons for the Learn mode feature
+model Lesson {
+  id        String   @id @default(cuid())
+  name      String   // Display name of the lesson
+  content   String   @db.Text // Markdown content of the lesson
+  sortOrder Int      @default(0) // Order in the lessons list
+  isPublished Boolean @default(true) // Whether the lesson is visible
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([sortOrder])
 }

--- a/prisma/seed-lessons.ts
+++ b/prisma/seed-lessons.ts
@@ -1,0 +1,399 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const lessons = [
+  {
+    name: 'Introduction to SRE',
+    sortOrder: 1,
+    isPublished: true,
+    content: `# Introduction to Site Reliability Engineering
+
+## What is SRE?
+
+Site Reliability Engineering (SRE) is a discipline that incorporates aspects of software engineering and applies them to infrastructure and operations problems. The main goals are to create scalable and highly reliable software systems.
+
+## Key Principles
+
+### 1. Embrace Risk
+Not everything needs to be 100% reliable. SREs work with product teams to determine appropriate availability targets based on business needs.
+
+### 2. Service Level Objectives (SLOs)
+SLOs are the tool SRE uses to set expectations for service reliability. They are defined as a percentage of time that a service should be available.
+
+### 3. Eliminate Toil
+Toil is manual, repetitive work that lacks enduring value. SREs aim to automate toil to free up time for project work.
+
+### 4. Monitoring and Alerting
+Effective monitoring is essential for maintaining reliability. SREs implement comprehensive monitoring to detect issues before they impact users.
+
+## The Four Golden Signals
+
+1. **Latency** - The time it takes to service a request
+2. **Traffic** - How much demand is being placed on your system
+3. **Errors** - The rate of requests that fail
+4. **Saturation** - How "full" your service is
+
+## Getting Started
+
+To begin your SRE journey:
+1. Start measuring your service's reliability
+2. Define SLOs based on user expectations
+3. Create error budgets to balance reliability and velocity
+4. Automate repetitive tasks
+5. Conduct blameless postmortems
+
+> "Hope is not a strategy." - SRE Mantra
+`,
+  },
+  {
+    name: 'Incident Management',
+    sortOrder: 2,
+    isPublished: true,
+    content: `# Incident Management
+
+## What is an Incident?
+
+An incident is any event that disrupts or reduces the quality of service, or which has the potential to do so. Effective incident management is crucial for maintaining reliability.
+
+## Incident Lifecycle
+
+### 1. Detection
+- Automated monitoring and alerting
+- User reports
+- Synthetic monitoring
+
+### 2. Triage
+- Assess severity and impact
+- Assign incident commander
+- Establish communication channels
+
+### 3. Response
+- Engage necessary responders
+- Document actions in real-time
+- Communicate status updates
+
+### 4. Resolution
+- Implement fix
+- Verify service restoration
+- Close incident
+
+### 5. Post-Incident Review
+- Conduct blameless postmortem
+- Document learnings
+- Create action items
+
+## Incident Roles
+
+| Role | Responsibility |
+|------|----------------|
+| Incident Commander | Overall incident coordination |
+| Communications Lead | External and internal updates |
+| Technical Lead | Directing technical investigation |
+| Scribe | Documentation and timeline |
+
+## Severity Levels
+
+\`\`\`
+Severity 1 (Critical): Complete service outage
+Severity 2 (High): Major feature unavailable
+Severity 3 (Medium): Minor feature unavailable
+Severity 4 (Low): Minimal impact
+\`\`\`
+
+## Best Practices
+
+- **Use standardized terminology** across your organization
+- **Maintain clear runbooks** for common incident types
+- **Practice incident response** with game days
+- **Always conduct postmortems** - even for minor incidents
+
+Remember: The goal is to restore service first, investigate root cause later.
+`,
+  },
+  {
+    name: 'Monitoring & Observability',
+    sortOrder: 3,
+    isPublished: true,
+    content: `# Monitoring & Observability
+
+## The Three Pillars of Observability
+
+### 1. Logs
+Logs are immutable, timestamped records of events. They provide detailed context about what happened in your system.
+
+\`\`\`json
+{
+  "timestamp": "2024-01-15T10:30:00Z",
+  "level": "ERROR",
+  "service": "payment-api",
+  "message": "Payment processing failed",
+  "user_id": "12345",
+  "error_code": "CARD_DECLINED"
+}
+\`\`\`
+
+### 2. Metrics
+Metrics are numeric measurements collected over time. They help you understand the state and performance of your system.
+
+Common metric types:
+- **Counter**: Always increasing (e.g., request count)
+- **Gauge**: Can go up or down (e.g., CPU usage)
+- **Histogram**: Distribution of values (e.g., request latency)
+
+### 3. Traces
+Traces follow a request as it travels through your distributed system, showing latency and relationships between services.
+
+## Key Metrics to Monitor
+
+### Application Metrics
+- Request rate (requests/second)
+- Error rate (errors/second)
+- Latency percentiles (p50, p95, p99)
+- Saturation (queue length, CPU, memory)
+
+### Infrastructure Metrics
+- CPU utilization
+- Memory usage
+- Disk I/O
+- Network throughput
+
+## Alerting Best Practices
+
+**Alert on symptoms, not causes:**
+- ❌ "CPU is at 90%"
+- ✅ "Request latency exceeds SLO"
+
+**Reduce alert fatigue:**
+- Set appropriate thresholds
+- Use multi-window alerting
+- Suppress flapping alerts
+
+## Tools Landscape
+
+| Category | Tools |
+|----------|-------|
+| Metrics | Prometheus, Datadog, New Relic |
+| Logging | ELK Stack, Splunk, Coralogix |
+| Tracing | Jaeger, Zipkin, Honeycomb |
+| APM | Datadog, New Relic, Dynatrace |
+
+## Building Effective Dashboards
+
+1. **SLO Overview** - Current SLI vs target
+2. **Service Health** - Error rates and latency
+3. **Infrastructure** - Resource utilization
+4. **Business Metrics** - User impact indicators
+`,
+  },
+  {
+    name: 'On-Call Best Practices',
+    sortOrder: 4,
+    isPublished: true,
+    content: `# On-Call Best Practices
+
+## Setting Up an On-Call Rotation
+
+### Team Size
+- Minimum 4-5 people for sustainable rotation
+- Maximum 1 week on-call per engineer
+- Include shadow shifts for training
+
+### Handoff Process
+1. Review open incidents
+2. Check recent deployments
+3. Document any known issues
+4. Update escalation contacts
+
+## During On-Call
+
+### When an Alert Fires
+
+1. **Acknowledge** the alert immediately
+2. **Assess** severity and impact
+3. **Communicate** in incident channel
+4. **Escalate** if needed
+5. **Resolve** and document
+
+### Managing Alert Fatigue
+
+\`\`\`
+Signs of alert fatigue:
+- Alerts are ignored or snoozed
+- Engineers burn out quickly
+- Response times increase
+- False positives dominate
+\`\`\`
+
+Combat this by:
+- Regular alert review and tuning
+- Automated remediation where possible
+- Clear runbooks for each alert
+- Blameless postmortems
+
+## Compensation and Support
+
+### Fair Compensation
+- On-call pay or time off
+- Clear escalation policies
+- Support from management
+
+### Work-Life Balance
+- Respect off-call time
+- Provide quiet hours where possible
+- Rotate holidays fairly
+
+## Building a Healthy On-Call Culture
+
+> "Being on-call is not about being a hero. It's about maintaining sustainable reliability."
+
+### Key Principles
+
+1. **Blameless culture** - Focus on systems, not people
+2. **Documentation** - Runbooks and postmortems
+3. **Automation** - Reduce manual intervention
+4. **Training** - Regular game days and shadowing
+5. **Support** - Management backing and resources
+
+## Metrics to Track
+
+| Metric | Target |
+|--------|--------|
+| MTTA (Mean Time to Acknowledge) | < 5 minutes |
+| MTTR (Mean Time to Resolve) | Varies by severity |
+| Pages per week | < 10 |
+| False positive rate | < 20% |
+`,
+  },
+  {
+    name: 'Kubernetes for SREs',
+    sortOrder: 5,
+    isPublished: true,
+    content: `# Kubernetes for SREs
+
+## Core Concepts
+
+### Pods
+The smallest deployable unit in Kubernetes. A pod can contain one or more containers.
+
+\`\`\`yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-app
+spec:
+  containers:
+  - name: app
+    image: my-app:1.0
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+\`\`\`
+
+### Deployments
+Manage the desired state of your application, including replicas and rolling updates.
+
+### Services
+Expose your application to network traffic and provide load balancing.
+
+## Key SRE Concerns
+
+### 1. Resource Management
+- Set appropriate resource requests and limits
+- Use Horizontal Pod Autoscaler (HPA)
+- Implement Pod Disruption Budgets (PDB)
+
+### 2. High Availability
+- Run multiple replicas
+- Use anti-affinity rules
+- Spread across availability zones
+
+\`\`\`yaml
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        topologyKey: topology.kubernetes.io/zone
+\`\`\`
+
+### 3. Observability
+- Deploy metrics exporters
+- Configure logging aggregation
+- Implement tracing
+
+## Common Issues and Solutions
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| OOMKilled | Memory limit exceeded | Increase limits or optimize app |
+| CrashLoopBackOff | Container keeps failing | Check logs, fix app issue |
+| Pending pods | Insufficient resources | Scale cluster or reduce requests |
+| ImagePullBackOff | Can't pull image | Check image name/registry auth |
+
+## Essential kubectl Commands
+
+\`\`\`bash
+# Get pod status
+kubectl get pods -o wide
+
+# Describe a pod
+kubectl describe pod <pod-name>
+
+# Check logs
+kubectl logs <pod-name> -f
+
+# Execute into a pod
+kubectl exec -it <pod-name> -- /bin/sh
+
+# Get events
+kubectl get events --sort-by='.lastTimestamp'
+\`\`\`
+
+## Reliability Patterns
+
+1. **Liveness probes** - Restart unhealthy containers
+2. **Readiness probes** - Remove from service until ready
+3. **Startup probes** - Allow slow-starting containers
+4. **Graceful shutdown** - Handle SIGTERM properly
+`,
+  },
+];
+
+async function seedLessons() {
+  console.log('Seeding lessons...');
+
+  for (const lesson of lessons) {
+    const existing = await prisma.lesson.findFirst({
+      where: { name: lesson.name },
+    });
+
+    if (existing) {
+      console.log(`Updating lesson: ${lesson.name}`);
+      await prisma.lesson.update({
+        where: { id: existing.id },
+        data: lesson,
+      });
+    } else {
+      console.log(`Creating lesson: ${lesson.name}`);
+      await prisma.lesson.create({
+        data: lesson,
+      });
+    }
+  }
+
+  console.log(`Seeded ${lessons.length} lessons`);
+}
+
+seedLessons()
+  .catch((error) => {
+    console.error('Error seeding lessons:', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/types/views.ts
+++ b/types/views.ts
@@ -8,7 +8,7 @@
 /**
  * Available view modes in TheBridge
  */
-export type ViewMode = 'chat' | 'dashboard' | 'multiagent';
+export type ViewMode = 'chat' | 'dashboard' | 'multiagent' | 'learn';
 
 /**
  * Agent status states


### PR DESCRIPTION
## Summary
Implements a new Learn Mode for TheBridge with educational SRE content.

Closes #84

## Changes Made

### New Components
- **RadialFAB**: Radial floating action button that expands to show mode options
  - Chat (yellow), Dashboard (orange), Learn (brown), Agents (indigo)
  - Arc-style radial expansion animation
- **LearnSidebar**: Left sidebar showing lessons list with brown theme
- **LessonContent**: Main content area displaying markdown lesson content
- **LearnContext**: State management for lessons and selection

### Database
- Add Lesson model to Prisma schema (name, content, sortOrder, isPublished)
- Seed 5 starter lessons:
  - Introduction to SRE
  - Incident Management
  - Monitoring & Observability
  - On-Call Best Practices
  - Kubernetes for SREs

### API Routes
- `GET/POST /api/lessons` - List all lessons, create new lesson
- `GET/PATCH/DELETE /api/lessons/[id]` - Individual lesson operations

### UI/UX
- Brown color theme (#a67c52) for Learn mode
- Smooth transitions between view modes
- Markdown rendering with prose styling
- Loading skeletons and empty states

### Integration
- Updated ViewMode type to include 'learn'
- Added LearnProvider to app layout
- Updated page.tsx to render LearnSidebar and LessonContent

## Test Plan
- [ ] Click radial FAB to expand mode options
- [ ] Select Learn mode - should show brown-themed sidebar
- [ ] Verify lessons appear in sidebar after database seed
- [ ] Click a lesson - content should display in main area
- [ ] Verify markdown renders correctly (headers, code blocks, tables)
- [ ] Switch between Chat, Dashboard, and Learn modes