### PR TITLE
fix: resolve max_tokens must be greater than budget_tokens error

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -195,6 +195,7 @@ export async function POST(request: NextRequest) {
       conversationLength: conversationHistory.length,
       hasFiles: files.length > 0,
       toolsEnabled: tools.length > 0,
+      extendedThinking,
     });
 
     // Get template instruction to add to system prompt


### PR DESCRIPTION
## Summary
Fixes the `max_tokens must be greater than thinking.budget_tokens` error (HTTP 400) that occurred when extended thinking was enabled.

## Problem
When extended thinking is enabled, Claude requires `max_tokens` to be greater than `thinking.budget_tokens`. The previous implementation could set `budget_tokens` up to 10,000 while `maxTokens` could be as low as 256, violating this constraint.

## Solution
- **Constrain thinking budget**: `getThinkingBudget()` now accepts `maxTokens` and ensures budget is always < maxTokens (leaves 1024 tokens for response)
- **Higher limits for extended thinking**: `enforceTokenLimits()` now supports min 4096 / max 16000 when extended thinking is enabled (vs 256/8192 standard)
- **Boost max_tokens**: `getResponseLengthConfig()` boosts max_tokens when extended thinking is enabled (min 8192 or 2x base config)
- **Pass context through**: Extended thinking flag is now passed through the entire configuration chain

## Test Plan
- [x] Build passes
- [x] Unit tests updated for new function signatures
- [x] Tests verify thinkingBudget < maxTokens invariant

Closes #82