### PR TITLE
feat: add Kubernetes MCP and categorize infrastructure MCPs

### DIFF
--- a/app/api/mcp/servers/route.ts
+++ b/app/api/mcp/servers/route.ts
@@ -13,6 +13,7 @@ export async function GET() {
     const servers = await prisma.mCPServerDefinition.findMany({
       where: { isEnabled: true },
       orderBy: [
+        { category: 'asc' },
         { isOfficial: 'desc' },
         { name: 'asc' },
       ],
@@ -22,6 +23,7 @@ export async function GET() {
         name: true,
         description: true,
         icon: true,
+        category: true,
         transportType: true,
         configTemplate: true,
         docsUrl: true,
@@ -49,7 +51,7 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
 
-    const { slug, name, description, icon, transportType, configTemplate, docsUrl, isOfficial } = body;
+    const { slug, name, description, icon, category, transportType, configTemplate, docsUrl, isOfficial } = body;
 
     if (!slug || !name || !configTemplate) {
       return NextResponse.json(
@@ -64,6 +66,7 @@ export async function POST(request: Request) {
         name,
         description,
         icon,
+        category: category || 'observability',
         transportType: transportType || 'sse',
         configTemplate: JSON.stringify(configTemplate),
         docsUrl,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,6 +155,7 @@ model MCPServerDefinition {
   name        String   // Display name
   description String?  // What this MCP server does
   icon        String?  // Icon identifier for UI
+  category    String   @default("observability") // "observability" | "infrastructure" | "productivity" | "data" | "devops"
 
   // Transport configuration
   transportType String  @default("sse") // "sse" | "http" | "stdio"


### PR DESCRIPTION
## Summary
Adds the Kubernetes MCP to the UI under a new Infrastructure MCPs section, as requested in issue #83. Also reorganizes all MCP servers into logical categories.

## Changes Made

### Database Schema
- Added `category` field to `MCPServerDefinition` model
- Categories: `observability`, `infrastructure`, `productivity`, `data`, `devops`

### MCP Server Reorganization
All servers now have proper categories:

**Infrastructure** (Kubernetes, Cloudflare, Shell):
- Kubernetes - Container orchestration via kubectl
- Shell/Terminal - Execute commands
- Cloudflare (6 servers) - CDN, DNS, Workers, Logs, Audit, GraphQL

**Observability** (Logging, Metrics, Incidents):
- Coralogix, New Relic, Rootly, Prometheus, Grafana

**Productivity** (Communication, Project Management):
- Jira, Confluence, GitHub, Slack, Gmail, Google Calendar, Figma, Zoom

**Data & Analytics**:
- Metabase, Snowflake, Airbyte

**DevOps** (CI/CD, Deployment):
- ArgoCD, Sidekiq, Chrome DevTools

### UI Changes
- Settings page now groups MCPs by category
- Each category has an icon, label, and description
- Infrastructure section prominently displays Kubernetes MCP

### API Updates
- `GET /api/mcp/servers` returns category field
- `POST /api/mcp/servers` accepts category parameter

## Test Plan
- [x] Build passes
- [x] Prisma schema updated
- [ ] After deploy: Run `npx tsx prisma/seed-mcp.ts` to update categories
- [ ] Verify /settings/mcp shows categorized sections

Closes #83