### PR TITLE
feat: Add CRUD functionality for Lessons with AI content generation

### DIFF
--- a/app/api/lessons/[id]/route.ts
+++ b/app/api/lessons/[id]/route.ts
@@ -49,13 +49,14 @@ export async function PATCH(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { name, content, sortOrder, isPublished } = body;
+    const { name, content, prompt, sortOrder, isPublished } = body;
 
     const lesson = await prisma.lesson.update({
       where: { id },
       data: {
         ...(name !== undefined && { name }),
         ...(content !== undefined && { content }),
+        ...(prompt !== undefined && { prompt }),
         ...(sortOrder !== undefined && { sortOrder }),
         ...(isPublished !== undefined && { isPublished }),
       },

--- a/app/api/lessons/generate/route.ts
+++ b/app/api/lessons/generate/route.ts
@@ -1,0 +1,115 @@
+/**
+ * Lesson Content Generation API
+ *
+ * POST /api/lessons/generate
+ * Generates lesson content using AI based on a name and prompt.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuthenticatedUser, getUserApiKey } from '@/lib/auth';
+
+// Get Anthropic client (creates per-request for user API key support)
+async function getAnthropicClient(): Promise<Anthropic> {
+  const user = await getAuthenticatedUser();
+
+  if (user?.id) {
+    // Try to get user's personal API key
+    const userApiKey = await getUserApiKey(user.id);
+    if (userApiKey) {
+      return new Anthropic({ apiKey: userApiKey });
+    }
+  }
+
+  // Fall back to server API key
+  return new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+}
+
+const LESSON_GENERATION_PROMPT = `You are an expert SRE educator creating content for "TheBridge", an AI-powered SRE command center training platform.
+
+Your task is to generate a comprehensive, well-structured lesson in Markdown format based on the given topic and prompt.
+
+Guidelines:
+- Use clear, hierarchical headings (## for main sections, ### for subsections)
+- Include practical examples and code snippets where relevant
+- Use tables for structured information
+- Include tips, warnings, and best practices in blockquotes
+- Keep explanations clear and accessible
+- Use bullet points and numbered lists for steps and key points
+- Include real-world scenarios and use cases
+- The content should be educational and actionable
+
+Format the content so it renders beautifully in a web application using markdown.`;
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getAuthenticatedUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const { name, prompt } = await request.json();
+
+    if (!name || typeof name !== 'string') {
+      return NextResponse.json(
+        { error: 'Lesson name is required' },
+        { status: 400 }
+      );
+    }
+
+    if (!prompt || typeof prompt !== 'string') {
+      return NextResponse.json(
+        { error: 'Lesson prompt is required' },
+        { status: 400 }
+      );
+    }
+
+    const anthropic = await getAnthropicClient();
+
+    const response = await anthropic.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 4096,
+      system: LESSON_GENERATION_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: `Create a lesson titled "${name}".
+
+Lesson requirements and focus:
+${prompt}
+
+Generate comprehensive, well-structured markdown content for this lesson. Start directly with the content (do not include the title as an H1 - it will be displayed separately).`,
+        },
+      ],
+    });
+
+    // Extract text content from response
+    const textContent = response.content.find(block => block.type === 'text');
+    const content = textContent?.type === 'text' ? textContent.text : '';
+
+    if (!content) {
+      return NextResponse.json(
+        { error: 'Failed to generate lesson content' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      content,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+      },
+    });
+  } catch (error) {
+    console.error('[Lessons API] Error generating content:', error);
+    return NextResponse.json(
+      { error: 'Failed to generate lesson content' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/lessons/route.ts
+++ b/app/api/lessons/route.ts
@@ -36,7 +36,7 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { name, content, sortOrder } = body;
+    const { name, content, prompt, sortOrder } = body;
 
     if (!name || !content) {
       return NextResponse.json(
@@ -45,11 +45,18 @@ export async function POST(request: Request) {
       );
     }
 
+    // Get the maximum sortOrder to place new lesson at the end
+    const maxSortOrder = await prisma.lesson.aggregate({
+      _max: { sortOrder: true },
+    });
+    const newSortOrder = sortOrder ?? ((maxSortOrder._max.sortOrder ?? 0) + 1);
+
     const lesson = await prisma.lesson.create({
       data: {
         name,
         content,
-        sortOrder: sortOrder ?? 0,
+        prompt,
+        sortOrder: newSortOrder,
       },
     });
 

--- a/components/LessonContent.tsx
+++ b/components/LessonContent.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useLearn } from '@/contexts/LearnContext';
 
@@ -71,8 +72,241 @@ function WelcomeState() {
   );
 }
 
+interface EditFormProps {
+  lessonId: string;
+  initialName: string;
+  initialContent: string;
+  initialPrompt: string | null | undefined;
+  onClose: () => void;
+}
+
+function EditForm({ lessonId, initialName, initialContent, initialPrompt, onClose }: EditFormProps) {
+  const { updateLesson, regenerateContent, deleteLesson, isSaving, isGenerating, error } = useLearn();
+  const [name, setName] = useState(initialName);
+  const [content, setContent] = useState(initialContent);
+  const [prompt, setPrompt] = useState(initialPrompt || '');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setLocalError(null);
+
+    if (!name.trim()) {
+      setLocalError('Lesson name is required');
+      return;
+    }
+
+    try {
+      await updateLesson(lessonId, {
+        name: name.trim(),
+        content,
+        prompt: prompt || undefined,
+      });
+      onClose();
+    } catch {
+      // Error is handled by context
+    }
+  };
+
+  const handleRegenerate = async () => {
+    setLocalError(null);
+
+    if (!prompt.trim()) {
+      setLocalError('Please provide a prompt to regenerate content');
+      return;
+    }
+
+    try {
+      const newContent = await regenerateContent(lessonId, prompt.trim());
+      setContent(newContent);
+    } catch {
+      // Error is handled by context
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteLesson(lessonId);
+      onClose();
+    } catch {
+      // Error is handled by context
+    }
+  };
+
+  const isProcessing = isSaving || isGenerating;
+  const displayError = localError || error;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-[var(--md-surface-container)] rounded-2xl shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden mx-4 flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[var(--md-outline-variant)]">
+          <h2 className="text-xl font-semibold text-[#a67c52]">Edit Lesson</h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-[var(--md-surface-container-high)] transition-colors"
+            disabled={isProcessing}
+          >
+            <svg className="w-5 h-5 text-[var(--md-on-surface-variant)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          {/* Name Input */}
+          <div>
+            <label className="block text-sm font-medium text-[var(--md-on-surface)] mb-1">
+              Lesson Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-4 py-2 rounded-lg bg-[var(--md-surface)] border border-[var(--md-outline-variant)] text-[var(--md-on-surface)] focus:outline-none focus:ring-2 focus:ring-[#a67c52] focus:border-transparent"
+              disabled={isProcessing}
+            />
+          </div>
+
+          {/* Prompt Input */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-[var(--md-on-surface)]">
+                Content Prompt
+              </label>
+              <button
+                onClick={handleRegenerate}
+                disabled={isProcessing || !prompt.trim()}
+                className="text-xs font-medium px-3 py-1 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5"
+                style={{
+                  backgroundColor: 'rgba(166, 124, 82, 0.15)',
+                  color: '#a67c52',
+                }}
+              >
+                {isGenerating ? (
+                  <>
+                    <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                    Regenerating...
+                  </>
+                ) : (
+                  <>
+                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                    </svg>
+                    Regenerate Content
+                  </>
+                )}
+              </button>
+            </div>
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Enter a prompt to regenerate content using AI"
+              rows={2}
+              className="w-full px-4 py-2 rounded-lg bg-[var(--md-surface)] border border-[var(--md-outline-variant)] text-[var(--md-on-surface)] placeholder:text-[var(--md-on-surface-variant)] focus:outline-none focus:ring-2 focus:ring-[#a67c52] focus:border-transparent resize-none"
+              disabled={isProcessing}
+            />
+          </div>
+
+          {/* Content Input */}
+          <div className="flex-1">
+            <label className="block text-sm font-medium text-[var(--md-on-surface)] mb-1">
+              Content (Markdown)
+            </label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={15}
+              className="w-full px-4 py-2 rounded-lg bg-[var(--md-surface)] border border-[var(--md-outline-variant)] text-[var(--md-on-surface)] font-mono text-sm focus:outline-none focus:ring-2 focus:ring-[#a67c52] focus:border-transparent resize-none"
+              disabled={isProcessing}
+            />
+          </div>
+
+          {displayError && (
+            <p className="text-sm text-[var(--md-error)]">{displayError}</p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-[var(--md-outline-variant)]">
+          <div>
+            {showDeleteConfirm ? (
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-[var(--md-error)]">Delete this lesson?</span>
+                <button
+                  onClick={handleDelete}
+                  disabled={isProcessing}
+                  className="px-3 py-1.5 text-sm font-medium rounded-lg bg-[var(--md-error)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+                >
+                  Yes, Delete
+                </button>
+                <button
+                  onClick={() => setShowDeleteConfirm(false)}
+                  disabled={isProcessing}
+                  className="px-3 py-1.5 text-sm font-medium rounded-lg bg-[var(--md-surface-container-high)] text-[var(--md-on-surface)] hover:opacity-90 transition-opacity"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={isProcessing}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg text-[var(--md-error)] hover:bg-[var(--md-error)]/10 transition-colors disabled:opacity-50"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+                Delete Lesson
+              </button>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onClose}
+              disabled={isProcessing}
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--md-surface-container-high)] text-[var(--md-on-surface)] hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={isProcessing}
+              className="px-4 py-2 text-sm font-medium rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              style={{ backgroundColor: '#a67c52' }}
+            >
+              {isSaving ? (
+                <>
+                  <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  Save Changes
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function LessonContent() {
   const { currentLesson, isLoadingContent, error } = useLearn();
+  const [isEditing, setIsEditing] = useState(false);
 
   // Loading state
   if (isLoadingContent) {
@@ -122,19 +356,36 @@ export default function LessonContent() {
       <div className="max-w-4xl mx-auto px-8 py-8">
         {/* Lesson Header */}
         <header className="mb-8 pb-6 border-b border-[var(--md-outline-variant)]">
-          <h1
-            className="text-3xl font-bold mb-2"
-            style={{ color: '#a67c52' }}
-          >
-            {currentLesson.name}
-          </h1>
-          <p className="text-sm text-[var(--md-on-surface-variant)]">
-            Last updated: {new Date(currentLesson.updatedAt).toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </p>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h1
+                className="text-3xl font-bold mb-2"
+                style={{ color: '#a67c52' }}
+              >
+                {currentLesson.name}
+              </h1>
+              <p className="text-sm text-[var(--md-on-surface-variant)]">
+                Last updated: {new Date(currentLesson.updatedAt).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </p>
+            </div>
+            <button
+              onClick={() => setIsEditing(true)}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-colors"
+              style={{
+                backgroundColor: 'rgba(166, 124, 82, 0.15)',
+                color: '#a67c52',
+              }}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+              Edit
+            </button>
+          </div>
         </header>
 
         {/* Lesson Content - Markdown */}
@@ -170,6 +421,17 @@ export default function LessonContent() {
           <ReactMarkdown>{currentLesson.content}</ReactMarkdown>
         </article>
       </div>
+
+      {/* Edit Modal */}
+      {isEditing && (
+        <EditForm
+          lessonId={currentLesson.id}
+          initialName={currentLesson.name}
+          initialContent={currentLesson.content}
+          initialPrompt={currentLesson.prompt}
+          onClose={() => setIsEditing(false)}
+        />
+      )}
     </div>
   );
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -354,6 +354,7 @@ model UsageSnapshot {
 model Lesson {
   id        String   @id @default(cuid())
   name      String   // Display name of the lesson
+  prompt    String?  @db.Text // AI prompt used to generate the content
   content   String   @db.Text // Markdown content of the lesson
   sortOrder Int      @default(0) // Order in the lessons list
   isPublished Boolean @default(true) // Whether the lesson is visible


### PR DESCRIPTION
## Summary
Implements complete CRUD functionality for the Learn Mode lessons feature, including AI-powered content generation.

## Changes Made
- **Schema**: Added `prompt` field to Lesson model for storing AI generation prompts
- **API**: Created `/api/lessons/generate` endpoint using Claude Sonnet for AI content generation
- **LearnSidebar**: Added "+" button and CreateLessonForm for creating new lessons with name and prompt
- **LessonContent**: Added EditForm modal with edit, delete, and regenerate content functionality
- **LearnContext**: Extended with `createLesson`, `updateLesson`, `deleteLesson`, `regenerateContent` methods
- **UX**: Added loading states (isGenerating, isSaving) for all async operations

## Features
- Create lessons by entering a name and prompt - AI generates the content automatically
- Edit existing lessons (name, prompt, content)
- Regenerate content for existing lessons with a new prompt
- Delete lessons with confirmation
- Visual feedback during loading states

## Test Plan
- [ ] Click the "+" button in the Learn sidebar to create a new lesson
- [ ] Enter a name and prompt, verify AI generates content
- [ ] Click on a lesson to view its content
- [ ] Click edit button to modify lesson name, prompt, or content
- [ ] Use "Regenerate Content" to generate new content with a different prompt
- [ ] Delete a lesson and verify it's removed from the list

Closes #87