### PR TITLE
Remove terminal/code button from chat interface

### DIFF
--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
-import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import TokenBudgetDisplay from './TokenBudgetDisplay';
 import QueryOptimizer from './QueryOptimizer';
@@ -817,14 +816,6 @@ const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(functi
         >
           {verbose ? '✓ Verbose' : 'Verbose'}
         </button>
-        <span className="text-[var(--md-outline-variant)]">|</span>
-        <Link
-          href="/code"
-          className="text-xs text-[var(--md-on-surface-variant)] hover:text-[var(--md-on-surface)] transition-colors duration-200"
-          title="View code examples"
-        >
-          Code
-        </Link>
         <span className="text-[var(--md-outline-variant)]">|</span>
         <button
           type="button"


### PR DESCRIPTION
Closes #92

## Summary
Removed the "Code" link button from the chat interface controls that opened a popup/modal with the code panel.

## Changes Made
- Removed Code link button from ChatInterface.tsx (lines 805-811)
- Removed preceding separator
- Removed unused `Link` import from `next/link`

## Testing
- Verified TypeScript compilation succeeds
- No new type errors introduced
- Code button is no longer visible in the chat interface controls