### PR TITLE
Remove extra optimize button next to token counter

### DIFF
--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -816,19 +816,6 @@ const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(functi
         >
           {verbose ? '✓ Verbose' : 'Verbose'}
         </button>
-        <span className="text-[var(--md-outline-variant)]">|</span>
-        <button
-          type="button"
-          onClick={() => setShowQueryOptimizer(!showQueryOptimizer)}
-          className={`text-xs transition-colors duration-200 ${
-            showQueryOptimizer
-              ? 'text-[var(--md-accent)] hover:text-[var(--md-accent-dark)]'
-              : 'text-[var(--md-on-surface-variant)] hover:text-[var(--md-on-surface)]'
-          }`}
-          title="Show query optimization hints"
-        >
-          {showQueryOptimizer ? '✓ Optimize' : 'Optimize'}
-        </button>
       </div>
 
       {/* Token Budget Display */}


### PR DESCRIPTION
Closes #93

## Summary
Removed the extra optimize button that appeared in the chat interface controls below the input field.

## Changes Made
- Removed the manual toggle button for query optimizer from the controls row
- Removed the separator pipe before it
- Query optimizer can still be triggered via the TokenUsageFeedback component when token usage is displayed
- Cleaned up unnecessary UI clutter

## Testing
- Verified the button is no longer visible in the chat interface
- Confirmed QueryOptimizer component is still functional via TokenUsageFeedback