### PR TITLE
fix: MCP page won't scroll

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -25,7 +25,7 @@ export function AppShell({ children }: AppShellProps) {
       <>
         <main
           id="main-content"
-          className="flex-1 flex flex-col min-h-0 overflow-hidden"
+          className="flex-1 flex flex-col min-h-0 overflow-y-auto"
           role="main"
         >
           {children}
@@ -39,7 +39,7 @@ export function AppShell({ children }: AppShellProps) {
     return (
       <main
         id="main-content"
-        className="flex-1 flex flex-col min-h-0 overflow-hidden"
+        className="flex-1 flex flex-col min-h-0 overflow-y-auto"
         role="main"
       >
         {children}
@@ -54,7 +54,7 @@ export function AppShell({ children }: AppShellProps) {
       <Header />
       <main
         id="main-content"
-        className="flex-1 flex flex-col min-h-0 overflow-hidden"
+        className="flex-1 flex flex-col min-h-0 overflow-y-auto"
         role="main"
       >
         {children}


### PR DESCRIPTION
Closes #99

## Summary
The MCP server management page was not scrollable because the main content container had `overflow-hidden` which prevented any overflow content from being visible or scrollable.

## Changes Made
- Changed the main content container's overflow from `overflow-hidden` to `overflow-y-auto` in AppShell.tsx
- This allows vertical scrolling when page content exceeds the viewport height
- Applied to all main content views (loading, unauthenticated, and authenticated states)