### PR TITLE
fix: Sidebar disappears in learn mode when collapsed

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -424,6 +424,25 @@ export default function Home() {
             />
           </div>
         )}
+        {/* Expand button when sidebar is hidden in learn mode */}
+        {showLearn && sidebarMode === 'hidden' && (
+          <button
+            onClick={cycleSidebarMode}
+            className="absolute left-0 top-1/2 -translate-y-1/2 z-10 p-2 rounded-r-lg bg-[var(--md-surface-container)] border border-l-0 border-[var(--md-outline-variant)] hover:bg-[var(--md-surface-container-high)] transition-colors"
+            title="Expand sidebar"
+            aria-label="Expand sidebar"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              className="w-4 h-4 text-[var(--md-on-surface-variant)]"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M9 18l6-6-6-6" />
+            </svg>
+          </button>
+        )}
       </aside>
 
       {/* Main Content */}


### PR DESCRIPTION
Closes #98

## Summary
When the sidebar is collapsed completely in learn mode, users had no way to re-expand it because the sidebar was completely hidden with no toggle button accessible.

## Changes Made
- Added a floating expand button that appears on the left edge when the sidebar is hidden in learn mode
- The button is styled to blend with the UI while remaining visible
- Clicking the button cycles the sidebar back to mini mode, then full mode

## Test Plan
1. Go to learn mode
2. Collapse the sidebar using the toggle button until it's fully hidden
3. Verify the expand button appears on the left edge
4. Click the expand button to restore the sidebar