### PR TITLE
feat: Add FAB mode switcher to MCP server management page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useSession } from "next-auth/react";
+import { useSearchParams } from 'next/navigation';
 import ChatInterface, { ChatInterfaceHandle } from "@/components/ChatInterface";
 import ToolsSidebar, { ALL_TOOL_IDS } from "@/components/ToolsSidebar";
 import LearnSidebar from "@/components/LearnSidebar";
@@ -25,6 +26,9 @@ export default function Home() {
   const { data: session, status } = useSession();
   const isAuthenticated = !!session;
   const isLoading = status === "loading";
+
+  // URL params for mode switching from other pages
+  const searchParams = useSearchParams();
 
   // Default all tools to enabled, will be updated from API
   const [enabledTools, setEnabledTools] = useState<Set<string>>(new Set(ALL_TOOL_IDS));
@@ -68,6 +72,16 @@ export default function Home() {
   const showDashboard = viewMode === 'dashboard';
   const showMultiAgent = viewMode === 'multiagent';
   const showLearn = viewMode === 'learn';
+
+  // Handle mode from URL params (e.g., from MCP settings page FAB)
+  useEffect(() => {
+    const modeParam = searchParams.get('mode');
+    if (modeParam && ['chat', 'dashboard', 'learn', 'multiagent'].includes(modeParam)) {
+      setViewMode(modeParam as ViewMode);
+      // Clean up URL after setting mode
+      window.history.replaceState({}, '', '/');
+    }
+  }, [searchParams, setViewMode]);
 
   // Load saved MCP configurations on mount
   useEffect(() => {

--- a/app/settings/mcp/page.tsx
+++ b/app/settings/mcp/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import MCPServerCard from '@/components/mcp/MCPServerCard';
+import RadialFAB from '@/components/RadialFAB';
+import type { ViewMode } from '@/types/views';
 
 interface MCPServer {
   id: string;
@@ -64,10 +67,16 @@ interface UserConfig {
 
 export default function MCPSettingsPage() {
   const { data: session } = useSession();
+  const router = useRouter();
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [userConfigs, setUserConfigs] = useState<UserConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Handle mode change from FAB - navigate to home with mode parameter
+  const handleModeChange = useCallback((mode: ViewMode) => {
+    router.push(`/?mode=${mode}`);
+  }, [router]);
 
   // Load available servers and user configurations
   useEffect(() => {
@@ -284,6 +293,12 @@ export default function MCPSettingsPage() {
           </div>
         )}
       </div>
+
+      {/* Radial FAB - Mode switcher */}
+      <RadialFAB
+        currentMode="dashboard"
+        onModeChange={handleModeChange}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #103

## Summary
Added the RadialFAB (floating action button) mode switcher to the MCP server management page, allowing users to quickly navigate to Chat, Dashboard, or Learn modes from the settings page.

## Changes Made
- Added RadialFAB component to `/settings/mcp` page
- Added URL mode parameter handling in home page to receive mode changes from other pages
- The FAB displays with a "dashboard" style since settings is related to configuration
- Clicking a mode navigates to the home page with the mode set

## Test Plan
1. Navigate to `/settings/mcp`
2. Verify the FAB appears in the bottom-right corner
3. Click the FAB to expand it
4. Select a different mode (Chat, Learn, Dashboard)
5. Verify navigation to home page with the correct mode active