### PR TITLE
fix: move welcome message above Kubernetes panel

### DIFF
--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -843,11 +843,8 @@ const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(functi
         <div className="flex flex-col flex-1 min-h-0 justify-center items-center px-4">
           {/* Centered content container */}
           <div className="w-full max-w-2xl flex flex-col items-center">
-            {/* Kubernetes Fact - educational content */}
-            <KubernetesFact />
-
-            {/* Greeting - positioned above input with spacing */}
-            <div className="mb-8">
+            {/* Greeting - centered between header and Kubernetes fact */}
+            <div className="mb-6">
               <div className="flex items-center justify-center gap-3">
                 <span className="text-[#fbbf24] text-4xl">✺</span>
                 <h2 className="text-4xl font-serif text-[var(--md-on-surface)]">
@@ -855,6 +852,9 @@ const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(functi
                 </h2>
               </div>
             </div>
+
+            {/* Kubernetes Fact - educational content below greeting */}
+            <KubernetesFact />
 
             {error && (
               <div className="py-2 mb-4 w-full bg-[var(--md-warning-container)] border border-[var(--md-warning)] rounded-lg">


### PR DESCRIPTION
## Summary
Moves the "AA-Ron returns!" welcome message to appear above the Kubernetes Knowledge panel in the chat empty state, centering it between the header and the educational content.

## Changes
- Swapped the order of the greeting and KubernetesFact components in ChatInterface.tsx
- Updated spacing (mb-6 instead of mb-8) for better visual balance
- Updated comments to reflect the new layout hierarchy

## Before
1. Kubernetes Knowledge panel
2. "AA-Ron returns!" greeting
3. Input form

## After
1. "AA-Ron returns!" greeting (centered between header and K8s fact)
2. Kubernetes Knowledge panel
3. Input form

Closes #114
Closes #116