### PR TITLE
feat: Move tools link to footer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -469,8 +469,6 @@ export default function Home() {
               <ChatInterface
                 ref={chatRef}
                 enabledTools={Array.from(enabledTools)}
-                onToggleTools={cycleSidebarMode}
-                toolsOpen={showDevTools}
                 onLoadingChange={setIsAgentActive}
                 conversationId={currentConversationId}
                 onConversationCreated={handleConversationCreated}

--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -41,8 +41,6 @@ interface Message {
 
 interface ChatInterfaceProps {
   enabledTools?: string[];
-  onToggleTools?: () => void;
-  toolsOpen?: boolean;
   onLoadingChange?: (isLoading: boolean) => void;
   conversationId?: string | null;
   onConversationCreated?: (id: string) => void;
@@ -64,7 +62,7 @@ export type { Message };
 const INPUT_HISTORY_KEY = 'thebridge-input-history';
 const MAX_HISTORY_SIZE = 50;
 
-const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(function ChatInterface({ enabledTools = [], onToggleTools, toolsOpen, onLoadingChange, conversationId, onConversationCreated }, ref) {
+const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(function ChatInterface({ enabledTools = [], onLoadingChange, conversationId, onConversationCreated }, ref) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [currentConversationId, setCurrentConversationId] = useState<string | null>(conversationId || null);
@@ -738,24 +736,8 @@ const ChatInterface = forwardRef<ChatInterfaceHandle, ChatInterfaceProps>(functi
         </div>
       )}
 
-      {/* Tools, Model, Extended Thinking, and Effort Toggles */}
+      {/* Model, Extended Thinking, and Effort Toggles */}
       <div className="mt-2 flex justify-center items-center gap-4 flex-wrap">
-        {onToggleTools && (
-          <>
-            <button
-              type="button"
-              onClick={onToggleTools}
-              className={`text-xs transition-colors duration-200 ${
-                toolsOpen
-                  ? 'text-[var(--md-accent)] hover:text-[var(--md-accent-dark)]'
-                  : 'text-[var(--md-on-surface-variant)] hover:text-[var(--md-on-surface)]'
-              }`}
-            >
-              {toolsOpen ? '✓ Tools' : 'Tools'}
-            </button>
-            <span className="text-[var(--md-outline-variant)]">|</span>
-          </>
-        )}
         <ResponseModeSelector value={responseMode} onChange={setResponseMode} />
         <span className="text-[var(--md-outline-variant)]">|</span>
         <div className="relative" ref={modelMenuRef}>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -21,6 +21,14 @@ export default function Footer() {
         </p>
         <span className="hidden md:block text-[var(--md-outline-variant)]">|</span>
         <Link
+          href="/settings/mcp"
+          className="text-xs text-[var(--md-on-surface-variant)] hover:text-[var(--md-on-surface)] transition-colors duration-200"
+          title="Manage MCP Tools"
+        >
+          Tools
+        </Link>
+        <span className="text-[var(--md-outline-variant)]">|</span>
+        <Link
           href="/code"
           className="text-xs text-[var(--md-on-surface-variant)] hover:text-[var(--md-on-surface)] transition-colors duration-200"
           title="View code examples"


### PR DESCRIPTION
## Summary
- Move the "Tools" link from below the chat input to the footer
- Tools link now appears next to "Hope is not a strategy" in the footer
- Link navigates to /settings/mcp (MCP Tool Hive management page)

## Changes Made
- Added "Tools" link to Footer.tsx that links to /settings/mcp
- Removed the Tools toggle button from ChatInterface.tsx
- Removed unused `onToggleTools` and `toolsOpen` props from ChatInterface
- Updated page.tsx to remove those prop references

## Test Plan
- [ ] Navigate to the app
- [ ] Verify "Tools" link appears in footer next to "Hope is not a strategy"
- [ ] Click "Tools" link and verify it navigates to /settings/mcp
- [ ] Verify the chat input area no longer has a "Tools" toggle below it

Closes #120