### PR TITLE
Persist New Relic account and entity selections

### DIFF
--- a/app/api/user/preferences/route.ts
+++ b/app/api/user/preferences/route.ts
@@ -1,0 +1,158 @@
+/**
+ * User Preferences API
+ *
+ * GET /api/user/preferences - Get all user preferences
+ * GET /api/user/preferences?key=xxx - Get a specific preference
+ * POST /api/user/preferences - Set a user preference
+ * DELETE /api/user/preferences?key=xxx - Delete a user preference
+ */
+
+import { NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
+
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const key = searchParams.get('key');
+
+    if (key) {
+      // Get specific preference
+      const preference = await prisma.userPreference.findUnique({
+        where: {
+          userId_key: {
+            userId: session.user.id,
+            key,
+          },
+        },
+      });
+
+      if (!preference) {
+        return NextResponse.json({ value: null });
+      }
+
+      return NextResponse.json({
+        key: preference.key,
+        value: JSON.parse(preference.value),
+      });
+    }
+
+    // Get all preferences
+    const preferences = await prisma.userPreference.findMany({
+      where: { userId: session.user.id },
+    });
+
+    const parsed = preferences.reduce((acc, pref) => {
+      acc[pref.key] = JSON.parse(pref.value);
+      return acc;
+    }, {} as Record<string, unknown>);
+
+    return NextResponse.json(parsed);
+  } catch (error) {
+    console.error('[Preferences API] Failed to fetch preferences:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch preferences' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { key, value } = body;
+
+    if (!key) {
+      return NextResponse.json(
+        { error: 'Missing required field: key' },
+        { status: 400 }
+      );
+    }
+
+    const preference = await prisma.userPreference.upsert({
+      where: {
+        userId_key: {
+          userId: session.user.id,
+          key,
+        },
+      },
+      update: {
+        value: JSON.stringify(value),
+      },
+      create: {
+        userId: session.user.id,
+        key,
+        value: JSON.stringify(value),
+      },
+    });
+
+    return NextResponse.json({
+      key: preference.key,
+      value: JSON.parse(preference.value),
+    });
+  } catch (error) {
+    console.error('[Preferences API] Failed to save preference:', error);
+    return NextResponse.json(
+      { error: 'Failed to save preference' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const key = searchParams.get('key');
+
+    if (!key) {
+      return NextResponse.json(
+        { error: 'Missing key parameter' },
+        { status: 400 }
+      );
+    }
+
+    await prisma.userPreference.delete({
+      where: {
+        userId_key: {
+          userId: session.user.id,
+          key,
+        },
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[Preferences API] Failed to delete preference:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete preference' },
+      { status: 500 }
+    );
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,6 +108,9 @@ model User {
   budget        Budget?
   usageSnapshots UsageSnapshot[]
   toolUsageStats ToolUsageStat[]
+
+  // User preferences
+  preferences   UserPreference[]
 }
 
 model Account {
@@ -344,6 +347,26 @@ model UsageSnapshot {
   @@unique([userId, period, periodStart])
   @@index([userId, period])
   @@index([periodStart])
+}
+
+// ============================================
+// User Preferences
+// ============================================
+
+// User preferences for integration settings (e.g., New Relic account/entity)
+model UserPreference {
+  id        String   @id @default(cuid())
+  userId    String
+  key       String   // e.g., "newrelic_account", "newrelic_entity"
+  value     String   @db.Text // JSON value
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, key])
+  @@index([userId])
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- Add database persistence for New Relic account and entity selections
- Users' selections are now saved and restored across sessions
- Entities API now accepts accountId parameter for filtering by selected account

## Changes Made
- Added `UserPreference` model to Prisma schema for storing user settings
- Created `/api/user/preferences` endpoint for CRUD operations on preferences
- Updated `/api/newrelic/entities` to accept `accountId` query parameter
- Updated `ToolsSidebar.tsx` McpDetailPanel to:
  - Load saved preferences on mount
  - Auto-restore saved account and entity selections
  - Persist selections when changed
  - Clear entity selection when account changes
  - Show loading/saving indicators

## Test Plan
- [ ] Open New Relic MCP panel in sidebar
- [ ] Select a different account
- [ ] Select an entity
- [ ] Refresh the page
- [ ] Open the panel again - selections should be restored
- [ ] Switch accounts - entity should clear and reload for new account

Closes #123