### PR TITLE
Remove the word label and the chip

### DIFF
--- a/components/header/GitHubIssueButton.tsx
+++ b/components/header/GitHubIssueButton.tsx
@@ -346,42 +346,8 @@ export default function GitHubIssueButton() {
                   />
                 </div>
 
-                {/* Label and Submit Row */}
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                  {/* Label */}
-                  <div>
-                    <label
-                      style={{
-                        display: 'block',
-                        fontSize: '11px',
-                        fontWeight: 600,
-                        color: colors.onSurfaceVariant,
-                        marginBottom: '8px',
-                        letterSpacing: '0.5px',
-                      }}
-                    >
-                      LABEL
-                    </label>
-                    <div
-                      style={{
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        gap: '6px',
-                        padding: '4px 10px',
-                        fontSize: '11px',
-                        fontWeight: 500,
-                        color: '#fff',
-                        background: colors.tertiary,
-                        border: `1px solid ${colors.tertiary}`,
-                        borderRadius: '12px',
-                      }}
-                    >
-                      <Icon name="check" size={12} decorative />
-                      claude-triage
-                    </div>
-                  </div>
-
-                  {/* Submit */}
+                {/* Submit Button */}
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
                   <button
                     type="submit"
                     disabled={isSubmitting || !formData.title.trim()}


### PR DESCRIPTION
Closes #130

## Summary
Removes the 'label' text and associated chip element from the lower left-hand corner of the GitHub issue form modal.

## Changes Made
- Removed "LABEL" text display
- Removed chip component showing "claude-triage"
- Adjusted layout to right-align submit button

## Testing
- [x] Modal still functions correctly
- [x] Layout is not broken
- [x] Submit button properly positioned