### PR TITLE
Improve Kubernetes fact of the day readability

### DIFF
--- a/components/KubernetesFact.tsx
+++ b/components/KubernetesFact.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 const KUBERNETES_FACTS = [
   // Pods
@@ -62,34 +62,30 @@ const KUBERNETES_FACTS = [
 ]
 
 export default function KubernetesFact() {
-  const [fact, setFact] = useState("")
-
-  useEffect(() => {
-    // Pick a random fact on mount
+  // Pick a random fact on mount
+  const [fact] = useState(() => {
     const randomIndex = Math.floor(Math.random() * KUBERNETES_FACTS.length)
-    setFact(KUBERNETES_FACTS[randomIndex])
-  }, [])
-
-  if (!fact) return null
+    return KUBERNETES_FACTS[randomIndex]
+  })
 
   return (
     <div className="mb-6 max-w-2xl mx-auto">
       <div
-        className="p-4 rounded-lg border"
+        className="p-5 rounded-lg border-2"
         style={{
           background: 'var(--md-primary-container)',
           borderColor: 'var(--md-outline-variant)',
         }}
       >
-        <div className="flex items-start gap-3">
+        <div className="flex items-start gap-4">
           <div
-            className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+            className="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0"
             style={{
               background: 'var(--md-primary)',
             }}
           >
             <span
-              className="material-symbols-outlined text-lg"
+              className="material-symbols-outlined text-xl"
               style={{ color: 'var(--md-on-primary)' }}
             >
               psychology
@@ -97,14 +93,20 @@ export default function KubernetesFact() {
           </div>
           <div className="flex-1">
             <div
-              className="text-xs font-semibold mb-1"
-              style={{ color: 'var(--md-on-primary-container)' }}
+              className="text-sm font-bold mb-2 tracking-wide uppercase"
+              style={{
+                color: 'var(--md-on-primary-container)',
+                opacity: 0.9
+              }}
             >
               Kubernetes Knowledge
             </div>
             <p
-              className="text-sm leading-relaxed"
-              style={{ color: 'var(--md-on-primary-container)' }}
+              className="text-base leading-relaxed font-medium"
+              style={{
+                color: 'var(--md-on-primary-container)',
+                lineHeight: '1.6'
+              }}
             >
               {fact}
             </p>


### PR DESCRIPTION
Closes #133

## Summary
Improves the readability of the Kubernetes fact of the day display with better typography, spacing, and contrast.

## Changes Made
- Increased font size from text-sm to text-base for better readability
- Improved title typography (text-xs to text-sm, bold, uppercase, tracking-wide)
- Increased padding from p-4 to p-5 for more breathing room
- Increased icon size from 8x8 to 10x10 for better visibility
- Added thicker border (border-2) for improved definition
- Improved spacing between icon and text (gap-3 to gap-4)
- Enhanced line height to 1.6 for better text flow
- Added font-medium to fact text for improved contrast
- Fixed React best practice: moved random fact selection to useState initializer

## Testing
- [x] Lint passes
- [x] Typography is more readable
- [x] Better visual hierarchy with improved spacing