### PR TITLE
Add Jira shortcut panel to header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,6 +7,7 @@ import { ThemeSwitch } from './ThemeSwitch';
 import { useTheme } from '@/lib/theme';
 import RoleSwitcher from './header/RoleSwitcher';
 import GitHubIssueButton from './header/GitHubIssueButton';
+import JiraIssueButton from './header/JiraIssueButton';
 import HeaderLauncherButton from './dashboard/HeaderLauncherButton';
 import { UserMenu } from './auth';
 
@@ -89,6 +90,7 @@ export default function Header() {
         {/* Status & Theme Controls */}
         <div className="flex items-center gap-2 sm:gap-3">
           <GitHubIssueButton />
+          <JiraIssueButton />
           <RoleSwitcher variant="chip" size="small" />
           <ThemeSwitch />
           <UserMenu />

--- a/components/header/JiraIssueButton.tsx
+++ b/components/header/JiraIssueButton.tsx
@@ -1,0 +1,444 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import Icon from '@/components/ui/Icon';
+import { colors } from '@/lib/colors';
+import JiraIssueList from './JiraIssueList';
+
+interface CreateStoryFormData {
+  summary: string;
+  description: string;
+}
+
+export default function JiraIssueButton() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<{ url: string; key: string } | null>(null);
+  const [formData, setFormData] = useState<CreateStoryFormData>({
+    summary: '',
+    description: '',
+  });
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Close panel when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // Reset form when opening
+  useEffect(() => {
+    if (isOpen) {
+      setFormData({ summary: '', description: '' });
+      setError(null);
+      setSuccess(null);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.summary.trim()) {
+      setError('Summary is required');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/jira', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+
+      const result = await response.json();
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to create story');
+      }
+
+      setSuccess({ url: result.data.url, key: result.data.key });
+      setFormData({ summary: '', description: '' });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create story');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      <button
+        ref={buttonRef}
+        onClick={() => setIsOpen(!isOpen)}
+        title="Jira Issues"
+        className="flex items-center justify-center rounded-full transition-all duration-200"
+        style={{
+          width: '32px',
+          height: '32px',
+          background: isOpen
+            ? `${colors.primary}33`
+            : 'var(--md-surface-container, rgba(255,255,255,0.05))',
+          border: `1px solid ${isOpen ? colors.primary : 'transparent'}`,
+          color: isOpen ? colors.primary : 'var(--md-on-surface-variant)',
+        }}
+        onMouseEnter={(e) => {
+          if (!isOpen) {
+            e.currentTarget.style.background = 'var(--md-surface-container-high)';
+          }
+        }}
+        onMouseLeave={(e) => {
+          if (!isOpen) {
+            e.currentTarget.style.background = 'var(--md-surface-container, rgba(255,255,255,0.05))';
+          }
+        }}
+      >
+        <Icon name="task" size={18} decorative />
+      </button>
+
+      {isOpen && (
+        <div
+          ref={panelRef}
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 8px)',
+            right: 0,
+            width: '800px',
+            background: colors.surfaceContainer,
+            border: `1px solid ${colors.outline}`,
+            borderRadius: '16px',
+            boxShadow: '0 8px 32px rgba(0,0,0,0.3)',
+            zIndex: 1000,
+            overflow: 'hidden',
+            display: 'flex',
+            maxHeight: '600px',
+          }}
+        >
+          {/* Left Column - Issue List */}
+          <div
+            style={{
+              flex: 1,
+              borderRight: `1px solid ${colors.outline}`,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <div
+              style={{
+                padding: '16px 20px',
+                borderBottom: `1px solid ${colors.outline}`,
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+              }}
+            >
+              <Icon name="list" size={20} style={{ color: colors.primary }} decorative />
+              <h3
+                style={{
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  color: colors.onSurface,
+                  margin: 0,
+                }}
+              >
+                Jira Issues
+              </h3>
+              <span
+                style={{
+                  fontSize: '11px',
+                  color: colors.onSurfaceVariant,
+                  fontWeight: 500,
+                }}
+              >
+                Platform Engineering
+              </span>
+            </div>
+            <div style={{ flex: 1, overflow: 'hidden', padding: '16px 20px' }}>
+              <JiraIssueList isOpen={isOpen} />
+            </div>
+          </div>
+
+          {/* Right Column - Create Story Form */}
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <div
+              style={{
+                padding: '16px 20px',
+                borderBottom: `1px solid ${colors.outline}`,
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+              }}
+            >
+              <Icon name="add_task" size={20} style={{ color: colors.primary }} decorative />
+              <div style={{ flex: 1 }}>
+                <h3
+                  style={{
+                    fontSize: '14px',
+                    fontWeight: 600,
+                    color: colors.onSurface,
+                    margin: 0,
+                  }}
+                >
+                  Create Jira Story
+                </h3>
+                <p
+                  style={{
+                    fontSize: '11px',
+                    color: colors.onSurfaceVariant,
+                    margin: 0,
+                  }}
+                >
+                  Add a new story to Platform Engineering
+                </p>
+              </div>
+              <button
+                onClick={() => setIsOpen(false)}
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  padding: '4px',
+                  cursor: 'pointer',
+                  color: colors.onSurfaceVariant,
+                  borderRadius: '8px',
+                }}
+              >
+                <Icon name="close" size={18} decorative />
+              </button>
+            </div>
+
+            {/* Form Content */}
+            <div style={{ padding: '16px 20px', flex: 1, overflowY: 'auto' }}>
+              {success ? (
+                <div
+                  style={{
+                    textAlign: 'center',
+                    padding: '24px 0',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: '48px',
+                      height: '48px',
+                      borderRadius: '50%',
+                      background: `${colors.success}22`,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      margin: '0 auto 16px',
+                    }}
+                  >
+                    <Icon name="check_circle" size={28} style={{ color: colors.success }} decorative />
+                  </div>
+                  <h4
+                    style={{
+                      fontSize: '16px',
+                      fontWeight: 600,
+                      color: colors.onSurface,
+                      margin: '0 0 8px',
+                    }}
+                  >
+                    Story {success.key} Created
+                  </h4>
+                  <a
+                    href={success.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      fontSize: '13px',
+                      color: colors.primary,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    View in Jira
+                    <Icon name="open_in_new" size={14} decorative />
+                  </a>
+                  <div style={{ marginTop: '16px' }}>
+                    <button
+                      onClick={() => setSuccess(null)}
+                      style={{
+                        padding: '8px 16px',
+                        fontSize: '13px',
+                        fontWeight: 500,
+                        color: colors.onSurface,
+                        background: colors.surfaceContainerHigh,
+                        border: 'none',
+                        borderRadius: '8px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Create Another
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmit}>
+                  {error && (
+                    <div
+                      style={{
+                        padding: '10px 12px',
+                        marginBottom: '12px',
+                        background: `${colors.error}15`,
+                        border: `1px solid ${colors.error}44`,
+                        borderRadius: '8px',
+                        fontSize: '12px',
+                        color: colors.error,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                      }}
+                    >
+                      <Icon name="error" size={16} decorative />
+                      {error}
+                    </div>
+                  )}
+
+                  {/* Summary */}
+                  <div style={{ marginBottom: '12px' }}>
+                    <label
+                      style={{
+                        display: 'block',
+                        fontSize: '11px',
+                        fontWeight: 600,
+                        color: colors.onSurfaceVariant,
+                        marginBottom: '6px',
+                        letterSpacing: '0.5px',
+                      }}
+                    >
+                      SUMMARY *
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.summary}
+                      onChange={(e) => setFormData(prev => ({ ...prev, summary: e.target.value }))}
+                      placeholder="Brief description of the story"
+                      disabled={isSubmitting}
+                      style={{
+                        width: '100%',
+                        padding: '10px 12px',
+                        fontSize: '13px',
+                        color: colors.onSurface,
+                        background: colors.surfaceContainerHigh,
+                        border: `1px solid ${colors.outline}`,
+                        borderRadius: '8px',
+                        outline: 'none',
+                      }}
+                      onFocus={(e) => {
+                        e.currentTarget.style.borderColor = colors.primary;
+                      }}
+                      onBlur={(e) => {
+                        e.currentTarget.style.borderColor = colors.outline;
+                      }}
+                    />
+                  </div>
+
+                  {/* Description */}
+                  <div style={{ marginBottom: '12px' }}>
+                    <label
+                      style={{
+                        display: 'block',
+                        fontSize: '11px',
+                        fontWeight: 600,
+                        color: colors.onSurfaceVariant,
+                        marginBottom: '6px',
+                        letterSpacing: '0.5px',
+                      }}
+                    >
+                      DESCRIPTION
+                    </label>
+                    <textarea
+                      value={formData.description}
+                      onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                      placeholder="Detailed description, acceptance criteria, etc."
+                      disabled={isSubmitting}
+                      rows={6}
+                      style={{
+                        width: '100%',
+                        padding: '10px 12px',
+                        fontSize: '13px',
+                        color: colors.onSurface,
+                        background: colors.surfaceContainerHigh,
+                        border: `1px solid ${colors.outline}`,
+                        borderRadius: '8px',
+                        outline: 'none',
+                        resize: 'vertical',
+                        fontFamily: 'inherit',
+                      }}
+                      onFocus={(e) => {
+                        e.currentTarget.style.borderColor = colors.primary;
+                      }}
+                      onBlur={(e) => {
+                        e.currentTarget.style.borderColor = colors.outline;
+                      }}
+                    />
+                  </div>
+
+                  {/* Submit Button */}
+                  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <button
+                      type="submit"
+                      disabled={isSubmitting || !formData.summary.trim()}
+                      style={{
+                        padding: '10px 20px',
+                        fontSize: '13px',
+                        fontWeight: 600,
+                        color: '#fff',
+                        background: `linear-gradient(135deg, ${colors.primary}, ${colors.primaryDark})`,
+                        border: 'none',
+                        borderRadius: '10px',
+                        cursor: isSubmitting || !formData.summary.trim() ? 'not-allowed' : 'pointer',
+                        opacity: isSubmitting || !formData.summary.trim() ? 0.6 : 1,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: '6px',
+                        transition: 'opacity 0.15s',
+                      }}
+                    >
+                      {isSubmitting ? (
+                        <>
+                          <Icon name="progress_activity" size={16} animate="animate-spin" decorative />
+                          Creating...
+                        </>
+                      ) : (
+                        <>
+                          <Icon name="add" size={16} decorative />
+                          Create Story
+                        </>
+                      )}
+                    </button>
+                  </div>
+                </form>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/header/JiraIssueList.tsx
+++ b/components/header/JiraIssueList.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import { useJiraData } from '@/hooks/useJiraData';
+import { colors } from '@/lib/colors';
+import Icon from '@/components/ui/Icon';
+import { Task, Epic } from '@/lib/jira/types';
+
+const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+type FilterType = 'all' | 'epics' | 'stories' | 'tasks';
+
+interface JiraIssueListProps {
+  isOpen: boolean;
+}
+
+export default function JiraIssueList({ isOpen }: JiraIssueListProps) {
+  const [filterType, setFilterType] = useState<FilterType>('all');
+  const [selectedEpic, setSelectedEpic] = useState<string>('all');
+  const { data, loading, error, refetch } = useJiraData(REFRESH_INTERVAL, isOpen ? Date.now() : undefined);
+
+  // Refetch when panel opens
+  useEffect(() => {
+    if (isOpen) {
+      refetch();
+    }
+  }, [isOpen, refetch]);
+
+  // Get unique epics for filter
+  const epics = useMemo(() => {
+    if (!data?.epics) return [];
+    return data.epics;
+  }, [data?.epics]);
+
+  // Filter items based on selected filters
+  const filteredItems = useMemo(() => {
+    if (!data) return [];
+
+    let items: Task[] = [];
+
+    // First filter by type
+    if (filterType === 'epics') {
+      items = data.epics;
+    } else if (filterType === 'stories') {
+      items = data.stories;
+    } else if (filterType === 'tasks') {
+      items = [...data.tasks, ...data.bugs];
+    } else {
+      items = [...data.epics, ...data.stories, ...data.tasks, ...data.bugs];
+    }
+
+    // Then filter by epic if selected
+    if (selectedEpic !== 'all') {
+      items = items.filter(item =>
+        item.key === selectedEpic || item.parentKey === selectedEpic
+      );
+    }
+
+    return items;
+  }, [data, filterType, selectedEpic]);
+
+  if (loading && !data) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <Icon name="progress_activity" size={20} animate="animate-spin" style={{ color: colors.onSurfaceVariant }} decorative />
+        <p style={{ fontSize: '12px', color: colors.onSurfaceVariant, marginTop: '8px' }}>
+          Loading Jira items...
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <Icon name="error" size={20} style={{ color: colors.error }} decorative />
+        <p style={{ fontSize: '12px', color: colors.error, marginTop: '8px' }}>
+          {error instanceof Error ? error.message : 'Failed to load Jira items'}
+        </p>
+        <button
+          onClick={refetch}
+          style={{
+            marginTop: '12px',
+            padding: '6px 12px',
+            fontSize: '11px',
+            background: colors.surfaceContainerHigh,
+            border: `1px solid ${colors.outline}`,
+            borderRadius: '6px',
+            color: colors.onSurface,
+            cursor: 'pointer',
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Filters */}
+      <div style={{ marginBottom: '12px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        {/* Type Filter */}
+        <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+          {(['all', 'epics', 'stories', 'tasks'] as FilterType[]).map(type => (
+            <button
+              key={type}
+              onClick={() => setFilterType(type)}
+              style={{
+                padding: '4px 10px',
+                fontSize: '11px',
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                background: filterType === type ? colors.tertiary : colors.surfaceContainerHigh,
+                color: filterType === type ? '#000' : colors.onSurfaceVariant,
+                border: 'none',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                transition: 'all 0.15s',
+              }}
+            >
+              {type}
+            </button>
+          ))}
+        </div>
+
+        {/* Epic Filter */}
+        {epics.length > 0 && (
+          <select
+            value={selectedEpic}
+            onChange={(e) => setSelectedEpic(e.target.value)}
+            style={{
+              padding: '6px 8px',
+              fontSize: '11px',
+              background: colors.surfaceContainerHigh,
+              border: `1px solid ${colors.outline}`,
+              borderRadius: '6px',
+              color: colors.onSurface,
+              cursor: 'pointer',
+            }}
+          >
+            <option value="all">All Epics</option>
+            {epics.map(epic => (
+              <option key={epic.key} value={epic.key}>
+                {epic.key} - {epic.title}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Issue List */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '6px',
+        }}
+      >
+        {filteredItems.length === 0 ? (
+          <div style={{ padding: '20px', textAlign: 'center' }}>
+            <Icon name="search_off" size={24} style={{ color: colors.onSurfaceVariant }} decorative />
+            <p style={{ fontSize: '12px', color: colors.onSurfaceVariant, marginTop: '8px' }}>
+              No items found
+            </p>
+          </div>
+        ) : (
+          filteredItems.map(item => {
+            const isBug = item.type === 'bug';
+            const isEpic = item.type === 'epic';
+            const statusColor =
+              item.statusCategory === 'done' ? colors.success :
+              item.statusCategory === 'inprogress' ? '#fbbf24' :
+              '#94a3b8';
+
+            return (
+              <a
+                key={item.id}
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                  padding: '8px',
+                  background: isBug ? `${colors.error}11` : colors.surfaceContainerHigh,
+                  border: `1px solid ${isBug ? colors.error : colors.outline}`,
+                  borderRadius: '8px',
+                  textDecoration: 'none',
+                  transition: 'all 0.15s',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = isBug ? `${colors.error}22` : colors.surfaceContainerHighest;
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = isBug ? `${colors.error}11` : colors.surfaceContainerHigh;
+                }}
+              >
+                {/* Status Indicator */}
+                <div
+                  style={{
+                    width: '8px',
+                    height: '8px',
+                    borderRadius: '50%',
+                    background: statusColor,
+                    flexShrink: 0,
+                  }}
+                />
+
+                {/* Type Icon */}
+                {isEpic && (
+                  <Icon name="bookmark" size={14} style={{ color: colors.tertiary }} decorative />
+                )}
+                {isBug && (
+                  <Icon name="bug_report" size={14} style={{ color: colors.error }} decorative />
+                )}
+                {item.type === 'task' && (
+                  <Icon name="task" size={14} style={{ color: colors.onSurfaceVariant }} decorative />
+                )}
+
+                {/* Key */}
+                <span
+                  style={{
+                    fontSize: '11px',
+                    fontFamily: 'monospace',
+                    fontWeight: 600,
+                    color: isBug ? colors.error : isEpic ? colors.tertiary : colors.primary,
+                    flexShrink: 0,
+                  }}
+                >
+                  {item.key}
+                </span>
+
+                {/* Title */}
+                <span
+                  style={{
+                    fontSize: '12px',
+                    color: colors.onSurface,
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {item.title}
+                </span>
+
+                {/* Assignee Avatar */}
+                {item.assignee && (
+                  <img
+                    src={item.assignee.avatar}
+                    alt={item.assignee.name}
+                    title={item.assignee.name}
+                    style={{
+                      width: '18px',
+                      height: '18px',
+                      borderRadius: '50%',
+                      flexShrink: 0,
+                    }}
+                  />
+                )}
+
+                {/* External Link Icon */}
+                <Icon
+                  name="open_in_new"
+                  size={12}
+                  style={{ color: colors.onSurfaceVariant, flexShrink: 0 }}
+                  decorative
+                />
+              </a>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #139

## Summary
Adds a Jira issues panel alongside the GitHub issues panel in the header, providing quick access to Jira items and the ability to create new stories.

## Changes Made
- ✅ Created **JiraIssueButton** component with task icon positioned next to GitHub bug icon
- ✅ Created **JiraIssueList** component with filtering capabilities
- ✅ Implemented split-panel design matching GitHub issues:
  - **Left panel**: Jira issue list with filters
  - **Right panel**: Create Jira Story form
- ✅ Added filtering by:
  - Type (All, Epics, Stories, Tasks)
  - Epic selection
  - Defaults to Platform Engineering project (PE)
- ✅ Leveraged existing `/api/jira` endpoints for data fetching and story creation

## Features
- **Quick Access**: Icon button in header for easy access
- **Smart Filtering**: Filter by issue type and epic
- **Create Stories**: Inline form to create new Jira stories
- **Consistent UX**: Matches GitHub panel design and behavior
- **Real-time Updates**: Auto-refreshes on panel open
- **Error Handling**: Graceful error states with retry functionality

## Technical Details
- Reuses existing Jira API infrastructure (`/api/jira/route.ts`, `/api/jira/issues/route.ts`)
- Uses `useJiraData` hook from existing Jira panel
- Follows same component pattern as GitHubIssueButton for consistency
- Material Design 3 compliant styling