### PR TITLE
Enter key submits GitHub issue

### DIFF
--- a/components/header/GitHubIssueButton.tsx
+++ b/components/header/GitHubIssueButton.tsx
@@ -326,6 +326,12 @@ export default function GitHubIssueButton() {
                   <textarea
                     value={formData.body}
                     onChange={(e) => setFormData({ body: e.target.value })}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        handleSubmit(e as unknown as React.FormEvent);
+                      }
+                    }}
                     placeholder="Describe the bug, feature request, or issue. We'll generate a title for you automatically."
                     disabled={isSubmitting}
                     rows={8}


### PR DESCRIPTION
Closes #152

## Summary
Added keyboard shortcut to submit GitHub issue creation form using the Enter key in the description textarea field.

## Changes Made
- Added `onKeyDown` event handler to description textarea in GitHubIssueButton component
- Enter key (without Shift modifier) now submits the form
- Shift+Enter continues to allow multi-line text entry
- Maintains existing form validation (description field required)

## Technical Details
- **File**: `components/header/GitHubIssueButton.tsx`
- **Handler**: Checks for Enter key press without Shift modifier
- **Behavior**: Prevents default newline insertion and triggers `handleSubmit`
- **UX**: Users can now quickly submit issues without clicking the button

## Testing
- ✅ Enter submits form when description is filled
- ✅ Enter respects validation (doesn't submit when description is empty)
- ✅ Shift+Enter adds new line without submitting
- ✅ Form submission follows normal flow with all validations