### PR TITLE
Show Rootly Create button in Dashboard

### DIFF
--- a/components/dashboard/DashboardPanel.tsx
+++ b/components/dashboard/DashboardPanel.tsx
@@ -16,6 +16,7 @@ export interface DashboardPanelProps {
   isLoading?: boolean;
   badge?: number | string;
   className?: string;
+  headerActions?: ReactNode; // Custom actions to render in header (e.g., Create button)
 }
 
 export default function DashboardPanel({
@@ -32,6 +33,7 @@ export default function DashboardPanel({
   isLoading = false,
   badge,
   className = '',
+  headerActions,
 }: DashboardPanelProps) {
   return (
     <div
@@ -82,6 +84,9 @@ export default function DashboardPanel({
 
         {/* Actions */}
         <div className="flex items-center gap-1">
+          {/* Custom Header Actions (e.g., Create button) */}
+          {headerActions}
+
           {/* Refresh Button */}
           {onRefresh && (
             <button

--- a/components/dashboard/RootlyPanel.tsx
+++ b/components/dashboard/RootlyPanel.tsx
@@ -453,16 +453,33 @@ export default function RootlyPanel({ compact = false, defaultExpanded = true, r
         <div className="flex-1 flex flex-col min-h-0">
           {/* Filter Row with View Mode Toggle */}
           <div className="flex items-center justify-between gap-2 mb-3 shrink-0">
-            {/* MD3 Segmented Button - View Mode Toggle */}
-            <div
-              className="inline-flex rounded-lg overflow-hidden shrink-0"
-              style={{
-                border: '1px solid var(--md-outline-variant)',
-                background: 'var(--md-surface-container-highest)',
-              }}
-              role="group"
-              aria-label="View mode"
-            >
+            <div className="flex items-center gap-2">
+              {/* Create Button (shown when embedded in Dashboard) */}
+              {embedded && (
+                <button
+                  onClick={() => setShowCreateModal(true)}
+                  className="px-2.5 py-1 rounded-full text-xs font-medium transition-all hover:shadow-md flex items-center gap-1"
+                  style={{
+                    background: '#7748F6',
+                    color: '#ffffff',
+                  }}
+                  aria-label="Create new incident"
+                >
+                  <Icon name="add" size={14} decorative />
+                  <span>Create</span>
+                </button>
+              )}
+
+              {/* MD3 Segmented Button - View Mode Toggle */}
+              <div
+                className="inline-flex rounded-lg overflow-hidden shrink-0"
+                style={{
+                  border: '1px solid var(--md-outline-variant)',
+                  background: 'var(--md-surface-container-highest)',
+                }}
+                role="group"
+                aria-label="View mode"
+              >
               <button
                 onClick={() => {
                   setViewMode('incidents');
@@ -494,6 +511,7 @@ export default function RootlyPanel({ compact = false, defaultExpanded = true, r
                 <Icon name="notifications_active" size={12} decorative />
                 <span>{alertsCount}</span>
               </button>
+              </div>
             </div>
 
             {/* Filter Chips - Only for Incidents (right-justified) */}


### PR DESCRIPTION
## Summary
Adds the Create Incident button to the Rootly panel when displayed in the Dashboard view.

## Problem
The Rootly panel has a Create button in its header, but when embedded in the Dashboard, the panel's own header is hidden (the Dashboard provides a common header wrapper). This meant users couldn't create incidents from the Dashboard view.

## Solution
- Added `headerActions` prop to `DashboardPanel` component for custom header actions
- Added Create button to RootlyPanel's filter row when `embedded={true}`
- Button appears next to the Incidents/Alerts toggle

## Changes Made
- `components/dashboard/DashboardPanel.tsx` - Added optional `headerActions` prop
- `components/dashboard/RootlyPanel.tsx` - Added Create button in filter row for embedded mode

## Testing
- [ ] Create button visible in Dashboard Rootly panel
- [ ] Clicking Create opens the incident creation modal
- [ ] Modal works correctly (form submission, validation)
- [ ] Create button still works in standalone RootlyPanel view