### PR TITLE
Replace Product Manager with Full Stack Developer and Data Scientist

### DIFF
--- a/components/header/RoleSwitcher.tsx
+++ b/components/header/RoleSwitcher.tsx
@@ -22,7 +22,8 @@ interface RoleSwitcherProps {
 // Simple emoji icons matching RoleBadge
 const ROLE_ICONS: Record<UserRole, string> = {
   sre: '⚡', // Speed/Lightning
-  pm: '📋', // Clipboard/Planning
+  fullstack: '💻', // Code/Development
+  datascientist: '📊', // Data/Analytics
 };
 
 const sizeStyles = {

--- a/components/sidebar/toolsData.tsx
+++ b/components/sidebar/toolsData.tsx
@@ -485,20 +485,32 @@ export const agents: AgentDefinition[] = [
       </svg>
     ),
   },
-  // PM agents
+  // Full Stack Developer agents
   {
-    id: 'story-creator',
-    name: 'Story Creator',
-    description: 'Expert user story & requirements writer',
-    accentColor: '#8b5cf6', // Purple (matches PM role color)
-    roles: ['pm'],
+    id: 'code-reviewer',
+    name: 'Code Reviewer',
+    description: 'Expert code review and best practices',
+    accentColor: '#3b82f6', // Blue (matches fullstack role color)
+    roles: ['fullstack'],
     icon: (
       <svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
-        <polyline points="14 2 14 8 20 8" />
-        <line x1="16" y1="13" x2="8" y2="13" />
-        <line x1="16" y1="17" x2="8" y2="17" />
-        <line x1="10" y1="9" x2="8" y2="9" />
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+  // Data Scientist agents
+  {
+    id: 'data-explorer',
+    name: 'Data Explorer',
+    description: 'Analyze and explore datasets',
+    accentColor: '#f59e0b', // Amber (matches datascientist role color)
+    roles: ['datascientist'],
+    icon: (
+      <svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2">
+        <line x1="18" y1="20" x2="18" y2="10" />
+        <line x1="12" y1="20" x2="12" y2="4" />
+        <line x1="6" y1="20" x2="6" y2="14" />
       </svg>
     ),
   },

--- a/data/roles.ts
+++ b/data/roles.ts
@@ -24,14 +24,23 @@ export const ROLE_DEFINITIONS: Record<UserRole, RoleDefinition> = {
     color: '#10b981', // Green
     shortName: 'SRE',
   },
-  pm: {
-    id: 'pm',
-    name: 'Product Manager',
+  fullstack: {
+    id: 'fullstack',
+    name: 'Full Stack Developer',
     description:
-      'Define product roadmap, prioritize features, and align stakeholders',
-    icon: 'Assignment', // Material UI icon (clipboard/task)
-    color: '#8b5cf6', // Purple
-    shortName: 'PM',
+      'Build end-to-end features, debug issues, and ship quality code',
+    icon: 'Code', // Material UI icon
+    color: '#3b82f6', // Blue
+    shortName: 'FS',
+  },
+  datascientist: {
+    id: 'datascientist',
+    name: 'Data Scientist',
+    description:
+      'Analyze data, build models, and derive insights from complex datasets',
+    icon: 'Analytics', // Material UI icon
+    color: '#f59e0b', // Amber
+    shortName: 'DS',
   },
 };
 
@@ -49,15 +58,25 @@ export const ROLE_TERMINOLOGY: Record<UserRole, TerminologyMap> = {
     knowledgeBaseLabel: 'SRE Wisdom',
     playbookLabel: 'Runbooks',
   },
-  pm: {
-    homeLabel: 'Product Hub',
-    homeSublabel: 'Roadmap and feature planning',
-    agentFloorLabel: 'Product Agents',
-    agentDeployAction: 'Launch Agent',
-    systemsLabel: 'Products',
-    healthLabel: 'Feature Status',
-    knowledgeBaseLabel: 'Product Docs',
-    playbookLabel: 'Playbooks',
+  fullstack: {
+    homeLabel: 'Developer Hub',
+    homeSublabel: 'Code, build, and ship',
+    agentFloorLabel: 'Dev Agents',
+    agentDeployAction: 'Spawn Agent',
+    systemsLabel: 'Services',
+    healthLabel: 'Build Status',
+    knowledgeBaseLabel: 'Dev Docs',
+    playbookLabel: 'Recipes',
+  },
+  datascientist: {
+    homeLabel: 'Data Lab',
+    homeSublabel: 'Analysis and insights',
+    agentFloorLabel: 'Data Agents',
+    agentDeployAction: 'Run Agent',
+    systemsLabel: 'Datasets',
+    healthLabel: 'Pipeline Status',
+    knowledgeBaseLabel: 'Data Docs',
+    playbookLabel: 'Notebooks',
   },
 };
 
@@ -108,34 +127,64 @@ export const ROLE_CONFIGS: Record<UserRole, RoleConfig> = {
     terminology: ROLE_TERMINOLOGY.sre,
   },
 
-  pm: {
-    role: 'pm',
+  fullstack: {
+    role: 'fullstack',
     showHomeDashboard: true,
     showAgentFloor: true,
-    showBuilderWorkspace: false,
-    visibleIntegrations: ['confluence', 'slack', 'github'],
+    showBuilderWorkspace: true,
+    visibleIntegrations: ['github', 'slack', 'confluence', 'newrelic'],
     defaultAgents: [
-      'roadmap-planner',
-      'feature-prioritizer',
-      'stakeholder-communicator',
+      'code-reviewer',
+      'bug-investigator',
+      'test-generator',
       'confluence-writer',
       'slack-notifier',
     ],
     recommendedAgents: [
-      'requirements-analyzer',
-      'user-feedback-summarizer',
-      'release-coordinator',
-      'metrics-reporter',
+      'refactoring-assistant',
+      'api-designer',
+      'performance-optimizer',
+      'documentation-generator',
     ],
     knowledgeBaseCategories: [
-      'product-strategy',
-      'roadmapping',
-      'user-research',
-      'stakeholder-management',
-      'release-planning',
+      'architecture',
+      'best-practices',
+      'debugging',
+      'testing',
+      'deployment',
     ],
-    playbookTypes: ['planning', 'communication', 'analysis'],
-    terminology: ROLE_TERMINOLOGY.pm,
+    playbookTypes: ['development', 'debugging', 'deployment'],
+    terminology: ROLE_TERMINOLOGY.fullstack,
+  },
+
+  datascientist: {
+    role: 'datascientist',
+    showHomeDashboard: true,
+    showAgentFloor: true,
+    showBuilderWorkspace: true,
+    visibleIntegrations: ['github', 'slack', 'confluence', 'newrelic'],
+    defaultAgents: [
+      'data-explorer',
+      'model-trainer',
+      'insight-generator',
+      'confluence-writer',
+      'slack-notifier',
+    ],
+    recommendedAgents: [
+      'feature-engineer',
+      'visualization-builder',
+      'experiment-tracker',
+      'pipeline-optimizer',
+    ],
+    knowledgeBaseCategories: [
+      'data-analysis',
+      'machine-learning',
+      'statistics',
+      'visualization',
+      'pipelines',
+    ],
+    playbookTypes: ['analysis', 'modeling', 'experimentation'],
+    terminology: ROLE_TERMINOLOGY.datascientist,
   },
 };
 

--- a/lib/roleStorage.ts
+++ b/lib/roleStorage.ts
@@ -17,11 +17,13 @@ function getDefaultPreferences(): UserRolePreferences {
     currentRole: DEFAULT_ROLE,
     favoriteAgents: {
       sre: [],
-      pm: [],
+      fullstack: [],
+      datascientist: [],
     },
     recentAgents: {
       sre: [],
-      pm: [],
+      fullstack: [],
+      datascientist: [],
     },
     roleViewPreferences: {
       sre: {
@@ -29,7 +31,12 @@ function getDefaultPreferences(): UserRolePreferences {
         agentFloorLayout: 'cards',
         agentFloorSortBy: 'category',
       },
-      pm: {
+      fullstack: {
+        dashboardLayout: 'detailed',
+        agentFloorLayout: 'cards',
+        agentFloorSortBy: 'category',
+      },
+      datascientist: {
         dashboardLayout: 'detailed',
         agentFloorLayout: 'cards',
         agentFloorSortBy: 'category',
@@ -37,7 +44,8 @@ function getDefaultPreferences(): UserRolePreferences {
     },
     roleThemes: {
       sre: 'sre-emerald', // Default emerald theme for SRE
-      pm: 'pm-violet', // Default violet theme for PM
+      fullstack: 'default-blue', // Default blue theme for Full Stack
+      datascientist: 'default-amber', // Default amber theme for Data Scientist
     },
     lastUpdated: new Date().toISOString(),
   };

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -111,16 +111,16 @@ Output format for quota analysis:
 Be specific with numbers. Prioritize recommendations by cost impact.`,
   },
 
-  // PM Role Agents
+  // Full Stack Developer Role Agents
   {
     slug: 'general',
-    role: 'pm',
+    role: 'fullstack',
     name: 'General Assistant',
-    description: 'Multi-purpose AI assistant for product management',
+    description: 'Multi-purpose AI assistant for full-stack development',
     icon: 'assistant',
     isDefault: true,
     sortOrder: 0,
-    systemPrompt: `You are a helpful AI assistant supporting product managers.
+    systemPrompt: `You are a helpful AI assistant supporting full-stack developers.
 
 Your capabilities include:
 - Reading, writing, and editing files
@@ -129,10 +129,36 @@ Your capabilities include:
 - Managing tasks and memory
 
 Focus on:
-- Clear documentation and communication
-- Tracking project status and dependencies
-- Analyzing data and metrics
-- Coordinating information across teams
+- Writing clean, maintainable code
+- Debugging and troubleshooting issues
+- API design and implementation
+- Testing and code review
+
+Be helpful, concise, and professional. Always explain your reasoning and provide clear answers.`,
+  },
+
+  // Data Scientist Role Agents
+  {
+    slug: 'general',
+    role: 'datascientist',
+    name: 'General Assistant',
+    description: 'Multi-purpose AI assistant for data science',
+    icon: 'assistant',
+    isDefault: true,
+    sortOrder: 0,
+    systemPrompt: `You are a helpful AI assistant supporting data scientists.
+
+Your capabilities include:
+- Reading, writing, and editing files
+- Searching the web for information
+- Running shell commands
+- Managing tasks and memory
+
+Focus on:
+- Data exploration and analysis
+- Building and evaluating models
+- Statistical analysis and insights
+- Visualization and reporting
 
 Be helpful, concise, and professional. Always explain your reasoning and provide clear answers.`,
   },

--- a/types/roles.ts
+++ b/types/roles.ts
@@ -8,7 +8,7 @@
 /**
  * Available user roles in TheBridge
  */
-export type UserRole = 'sre' | 'pm';
+export type UserRole = 'sre' | 'fullstack' | 'datascientist';
 
 /**
  * Role metadata and configuration


### PR DESCRIPTION
Closes #159

## Summary
Replaces the "Product Manager" role in the header role dropdown with two new roles:
- **Full Stack Developer** - For developers building end-to-end features
- **Data Scientist** - For data analysis, ML, and insights work

## Changes Made
- Updated `types/roles.ts`: Changed `UserRole` type from `'sre' | 'pm'` to `'sre' | 'fullstack' | 'datascientist'`
- Updated `data/roles.ts`: Added complete role definitions with:
  - Role metadata (name, description, icon, color)
  - Role-specific terminology
  - Visible integrations and agent configurations
- Updated `components/header/RoleSwitcher.tsx`: Added emoji icons for new roles
- Updated `lib/roleStorage.ts`: Added default preferences for new roles
- Updated `prisma/seed.ts`: Added general assistant agents for new roles
- Updated `components/sidebar/toolsData.tsx`: Added role-specific agents

## Role Details

| Role | Icon | Color | Description |
|------|------|-------|-------------|
| Full Stack Developer | 💻 / Code | Blue (#3b82f6) | Build end-to-end features, debug issues, ship code |
| Data Scientist | 📊 / Analytics | Amber (#f59e0b) | Analyze data, build models, derive insights |

## Testing
- [x] TypeScript compiles without role-related errors
- [ ] Manual testing: role dropdown shows new options
- [ ] Manual testing: switching roles updates UI correctly