### PR TITLE
Ensure New Relic MCP calls use user's saved configuration

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -10,6 +10,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { NextRequest } from 'next/server';
 import { SYSTEM_PROMPT } from '@/lib/prompts';
 import { loadMCPTools, executeMCPTool, closeMCPConnections, getAllUserMCPCategories } from '@/lib/mcp/client';
+import { getUserIntegrationContext, buildContextPrompt } from '@/lib/prompts/userContext';
 import { getAuthenticatedUser, getUserApiKey } from '@/lib/auth';
 import { prisma } from '@/lib/db';
 import {
@@ -211,6 +212,10 @@ export async function POST(request: NextRequest) {
       extendedThinking,
     });
 
+    // Get user's integration context (New Relic account, entity, etc.)
+    const userContext = user?.id ? await getUserIntegrationContext(user.id) : {};
+    const userContextPrompt = buildContextPrompt(userContext);
+
     // Get template instruction to add to system prompt
     const templateInstruction = getTemplateInstruction(message);
     const enhancedSystemPrompt = `${SYSTEM_PROMPT}
@@ -218,7 +223,7 @@ export async function POST(request: NextRequest) {
 Response Guidelines:
 ${templateInstruction}
 
-Be concise and direct. Avoid unnecessary preambles or verbose explanations.`;
+Be concise and direct. Avoid unnecessary preambles or verbose explanations.${userContextPrompt}`;
 
     // Log AI request with formatted output
     logAIRequest({

--- a/components/header/GitHubIssueList.tsx
+++ b/components/header/GitHubIssueList.tsx
@@ -17,6 +17,7 @@ interface GitHubIssue {
 }
 
 interface GitHubIssueListProps {
+  isOpen?: boolean;
   onRefresh?: () => void;
 }
 

--- a/components/header/JiraIssueList.tsx
+++ b/components/header/JiraIssueList.tsx
@@ -77,7 +77,7 @@ export default function JiraIssueList({ isOpen }: JiraIssueListProps) {
       <div style={{ padding: '20px', textAlign: 'center' }}>
         <Icon name="error" size={20} style={{ color: colors.error }} decorative />
         <p style={{ fontSize: '12px', color: colors.error, marginTop: '8px' }}>
-          {error instanceof Error ? error.message : 'Failed to load Jira items'}
+          {error || 'Failed to load Jira items'}
         </p>
         <button
           onClick={refetch}

--- a/lib/prompts/userContext.ts
+++ b/lib/prompts/userContext.ts
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview User Context for System Prompts
+ *
+ * @description
+ * Builds user-specific context to inject into system prompts.
+ * This includes user preferences for integrations like New Relic,
+ * Coralogix, etc.
+ *
+ * @usage
+ * Used by app/api/chat/route.ts to add user context to prompts.
+ */
+
+import { prisma } from '@/lib/db';
+
+export interface NewRelicContext {
+  accountId?: number;
+  accountName?: string;
+  entityGuid?: string;
+  entityName?: string;
+  entityDomain?: string;
+  categories?: string[];
+}
+
+export interface UserIntegrationContext {
+  newrelic?: NewRelicContext;
+}
+
+/**
+ * Fetch user's New Relic preferences from database
+ */
+export async function getUserNewRelicContext(userId: string): Promise<NewRelicContext | null> {
+  try {
+    // Fetch account and entity preferences
+    const [accountPref, entityPref, mcpConfig] = await Promise.all([
+      prisma.userPreference.findUnique({
+        where: { userId_key: { userId, key: 'newrelic_account' } },
+      }),
+      prisma.userPreference.findUnique({
+        where: { userId_key: { userId, key: 'newrelic_entity' } },
+      }),
+      prisma.userMCPConfig.findFirst({
+        where: {
+          userId,
+          isEnabled: true,
+          server: { slug: 'newrelic' },
+        },
+      }),
+    ]);
+
+    const context: NewRelicContext = {};
+
+    // Parse account preference
+    if (accountPref?.value) {
+      try {
+        const account = JSON.parse(accountPref.value);
+        context.accountId = account.id;
+        context.accountName = account.name;
+      } catch (e) {
+        console.error('[UserContext] Failed to parse New Relic account:', e);
+      }
+    }
+
+    // Parse entity preference
+    if (entityPref?.value) {
+      try {
+        const entity = JSON.parse(entityPref.value);
+        context.entityGuid = entity.guid;
+        context.entityName = entity.name;
+        context.entityDomain = entity.domain;
+      } catch (e) {
+        console.error('[UserContext] Failed to parse New Relic entity:', e);
+      }
+    }
+
+    // Parse MCP config for categories
+    if (mcpConfig?.config) {
+      try {
+        const config = JSON.parse(mcpConfig.config);
+        if (config.categories && Array.isArray(config.categories)) {
+          context.categories = config.categories;
+        }
+      } catch (e) {
+        console.error('[UserContext] Failed to parse New Relic MCP config:', e);
+      }
+    }
+
+    // Return null if no context found
+    if (Object.keys(context).length === 0) {
+      return null;
+    }
+
+    return context;
+  } catch (error) {
+    console.error('[UserContext] Failed to fetch New Relic context:', error);
+    return null;
+  }
+}
+
+/**
+ * Fetch all user integration context
+ */
+export async function getUserIntegrationContext(userId: string): Promise<UserIntegrationContext> {
+  const context: UserIntegrationContext = {};
+
+  const newrelicContext = await getUserNewRelicContext(userId);
+  if (newrelicContext) {
+    context.newrelic = newrelicContext;
+  }
+
+  return context;
+}
+
+/**
+ * Build a context string to append to the system prompt
+ */
+export function buildContextPrompt(context: UserIntegrationContext): string {
+  const sections: string[] = [];
+
+  if (context.newrelic) {
+    const nr = context.newrelic;
+    const lines: string[] = [];
+
+    lines.push('**User\'s New Relic Configuration:**');
+
+    if (nr.accountId) {
+      lines.push(`- **Account**: ${nr.accountName || 'Unknown'} (ID: ${nr.accountId})`);
+      lines.push(`  - IMPORTANT: When making New Relic API calls, ALWAYS use account_id=${nr.accountId}`);
+    }
+
+    if (nr.entityGuid) {
+      lines.push(`- **Selected Entity**: ${nr.entityName || 'Unknown'} (${nr.entityDomain || 'Unknown'})`);
+      lines.push(`  - Entity GUID: ${nr.entityGuid}`);
+      lines.push(`  - When the user asks about "the app" or "the service" without specifying, use this entity`);
+    }
+
+    if (nr.categories && nr.categories.length > 0) {
+      lines.push(`- **Enabled Tool Categories**: ${nr.categories.join(', ')}`);
+      lines.push(`  - Focus your New Relic queries on these areas unless the user asks otherwise`);
+    }
+
+    if (lines.length > 1) {
+      sections.push(lines.join('\n'));
+    }
+  }
+
+  if (sections.length === 0) {
+    return '';
+  }
+
+  return `\n\n## USER INTEGRATION CONTEXT\n\n${sections.join('\n\n')}`;
+}


### PR DESCRIPTION
Closes #162

## Summary
- Add user context injection into system prompts so Claude uses the user's saved New Relic configuration
- When making New Relic API calls, Claude will now automatically use the user's selected account ID
- When the user asks about "the app" or "the service", Claude will use the user's selected entity

## Changes Made
- Created `lib/prompts/userContext.ts` with functions to:
  - `getUserNewRelicContext()` - Fetches user's saved account, entity, and category preferences from database
  - `getUserIntegrationContext()` - Aggregated user integration context (extensible for other integrations)
  - `buildContextPrompt()` - Formats context as markdown for injection into system prompt
- Updated `app/api/chat/route.ts` to fetch and inject user context into the system prompt
- Fixed TypeScript errors in `GitHubIssueList.tsx` and `JiraIssueList.tsx` components

## How It Works
The system prompt now includes a section like:

```markdown
## USER INTEGRATION CONTEXT

**User's New Relic Configuration:**
- **Account**: Production (ID: 12345)
  - IMPORTANT: When making New Relic API calls, ALWAYS use account_id=12345
- **Selected Entity**: MyApp (APM)
  - Entity GUID: xyz123...
  - When the user asks about "the app" or "the service" without specifying, use this entity
- **Enabled Tool Categories**: errors, incidents, apm
  - Focus your New Relic queries on these areas unless the user asks otherwise
```

## Test Plan
- [ ] Configure New Relic account in the right panel
- [ ] Select a New Relic entity
- [ ] Ask Claude about New Relic data
- [ ] Verify Claude uses the correct account_id in API calls
- [ ] Verify Claude references the selected entity when asking about "the app"