### PR TITLE
Require Claude to announce before New Relic MCP calls

### DIFF
--- a/lib/prompts/userContext.ts
+++ b/lib/prompts/userContext.ts
@@ -138,6 +138,18 @@ export function buildContextPrompt(context: UserIntegrationContext): string {
       lines.push(`  - Focus your New Relic queries on these areas unless the user asks otherwise`);
     }
 
+    // Add announcement requirement
+    lines.push('');
+    lines.push('**IMPORTANT - Before calling any New Relic MCP tool:**');
+    lines.push('You MUST first announce to the user what you are about to do. Include:');
+    lines.push('1. The Account ID you will use');
+    lines.push('2. The Entity name (if applicable)');
+    lines.push('3. The specific tool(s) you will call');
+    lines.push('4. If running an NRQL query, show the query');
+    lines.push('');
+    lines.push('Example announcement:');
+    lines.push('> "I\'m about to query New Relic using account **' + (nr.accountName || nr.accountId || 'your account') + '** (ID: ' + (nr.accountId || 'N/A') + ')' + (nr.entityName ? ` for entity **${nr.entityName}**` : '') + '. I\'ll use the `execute_nrql_query` tool with the following NRQL: `SELECT count(*) FROM Transaction`"');
+
     if (lines.length > 1) {
       sections.push(lines.join('\n'));
     }


### PR DESCRIPTION
Closes #167

## Summary
Claude will now announce to the user before making any New Relic MCP calls, providing visibility into the account, entity, and tools being used.

## Changes Made
Updated `lib/prompts/userContext.ts` to add instructions in the system prompt requiring Claude to announce:

1. **Account ID** - Which New Relic account will be queried
2. **Entity name** - If targeting a specific entity
3. **Tool(s)** - Which MCP tool(s) will be called
4. **NRQL query** - If running a custom query, show it first

## Example Output
Before making a New Relic call, Claude will say something like:

> "I'm about to query New Relic using account **Production** (ID: 12345) for entity **MyApp**. I'll use the `execute_nrql_query` tool with the following NRQL: `SELECT count(*) FROM Transaction WHERE appName = 'MyApp' SINCE 1 hour ago`"

## Test Plan
- [ ] Configure New Relic account and entity in settings
- [ ] Ask Claude a question that requires New Relic data
- [ ] Verify Claude announces the account, entity, and tool before calling
- [ ] If NRQL is involved, verify the query is shown